### PR TITLE
fix: composite alpha and normalise transparent pixels (#34, #60)

### DIFF
--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -22,6 +22,7 @@ fn bench_cache_key(c: &mut Criterion) {
         grayscale: Some(false),
         enlarge: false,
         quality: None,
+        background: None,
     };
 
     c.bench_function("cache_key/generate_key", |b| {

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -24,6 +24,7 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         grayscale: None,
         enlarge: false,
         quality: None,
+        background: None,
     }
 }
 

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -141,6 +141,19 @@ pub struct ResizeQuery {
     /// the concurrently-landing lossy-WebP encoding work
     /// (`src/services/image/handler.rs`, owned by another agent).
     pub quality: Option<u8>,
+
+    /// Background colour, as an `[R, G, B]` triple (imgproxy's
+    /// `background`/`bg:{R}:{G}:{B}` or `bg:{hex}` processing option, #34).
+    /// `None` means "use the default" - `ImageService` (`src/services/image/handler.rs`)
+    /// defaults to opaque white, not imgproxy's own "disabled" default,
+    /// since this crate always flattens alpha before encoding to a format
+    /// without an alpha channel rather than treating flattening as opt-in.
+    /// Used two ways there: to flatten transparency against when encoding
+    /// to a format with no alpha channel (JPEG), and as the fill colour for
+    /// fully-transparent pixels when encoding to a format that keeps alpha
+    /// (PNG/WebP), so invisible pixels compress instead of carrying whatever
+    /// garbage RGB the source had under `alpha=0` (#60).
+    pub background: Option<[u8; 3]>,
 }
 
 /// Path parameter for the (unsigned, key-validated) download route

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -271,6 +271,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         }
     }
 

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -114,6 +114,7 @@ impl ParsedRequest {
             grayscale: self.options.grayscale,
             enlarge: self.options.enlarge.unwrap_or(false),
             quality: self.options.quality,
+            background: self.options.background,
         }
     }
 }
@@ -151,7 +152,8 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
-        let path = format!("/SIG/rs:fill:300:300/q:80/bl:5/g:true/el:1/{encoded}.webp");
+        let path =
+            format!("/SIG/rs:fill:300:300/q:80/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp");
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
         let query = parsed.into_resize_query();
@@ -165,6 +167,7 @@ mod tests {
         assert_eq!(query.grayscale, Some(true));
         assert!(query.enlarge);
         assert_eq!(query.format, ImageFormat::Webp);
+        assert_eq!(query.background, Some([255, 0, 0]));
     }
 
     #[test]
@@ -184,6 +187,7 @@ mod tests {
         assert_eq!(query.blur_sigma, None);
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);
+        assert_eq!(query.background, None);
     }
 
     #[test]

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -21,6 +21,10 @@ pub struct ProcessingOptions {
     pub grayscale: Option<bool>,
     pub enlarge: Option<bool>,
     pub quality: Option<u8>,
+    /// `bg`'s parsed `[R, G, B]` triple (#34) - see
+    /// [`crate::models::params::ResizeQuery::background`] for how it's
+    /// consumed.
+    pub background: Option<[u8; 3]>,
 }
 
 /// A processing-option path segment always contains a `:` (`rs:fill:300:300`,
@@ -74,6 +78,12 @@ impl ProcessingOptions {
                 "el" => {
                     let [value] = require_args::<1>(&args, segment)?;
                     opts.enlarge = Some(parse_bool(value, segment)?);
+                }
+                // bg:{R}:{G}:{B} or bg:{hex} (imgproxy's `background`/`bg`
+                // option, #34/#60). See `parse_background` for the accepted
+                // argument shapes.
+                "bg" => {
+                    opts.background = Some(parse_background(&args, segment)?);
                 }
                 other => return Err(UrlParseError::UnknownOption(other.to_string())),
             }
@@ -147,6 +157,74 @@ fn parse_bool(raw: &str, segment: &str) -> Result<bool, UrlParseError> {
             option: segment.to_string(),
             reason: format!("{other:?} is not a valid boolean (expected true/false/1/0)"),
         }),
+    }
+}
+
+/// Parses `bg`'s argument list into an `[R, G, B]` triple. imgproxy accepts
+/// two shapes for this option
+/// (<https://docs.imgproxy.net/usage/processing#background>):
+/// - `bg:{R}:{G}:{B}` - three separate 0-255 channel values (3 args here).
+/// - `bg:{hex_color}` - a single hex-coded colour (1 arg here). Accepts
+///   3-digit (`fff`) or 6-digit (`ffffff`) hex, case-insensitively, with no
+///   leading `#` - a literal `#` would need percent-encoding to survive as
+///   a path segment, so this mirrors how imgproxy's own examples write hex
+///   colours in URLs.
+///
+/// Any other argument count is rejected the same way `require_args` rejects
+/// a wrong count for the fixed-arity options above.
+fn parse_background(args: &[&str], segment: &str) -> Result<[u8; 3], UrlParseError> {
+    match args {
+        [r, g, b] => Ok([
+            parse_bounded(r, segment, 0, 255)?,
+            parse_bounded(g, segment, 0, 255)?,
+            parse_bounded(b, segment, 0, 255)?,
+        ]),
+        [hex] => parse_hex_color(hex, segment),
+        _ => Err(UrlParseError::InvalidOptionValue {
+            option: segment.to_string(),
+            reason: "expected either 3 arguments (R:G:B) or 1 argument (hex colour)".to_string(),
+        }),
+    }
+}
+
+/// Parses a 3-digit or 6-digit hex colour (no leading `#`) into `[R, G, B]`.
+fn parse_hex_color(hex: &str, segment: &str) -> Result<[u8; 3], UrlParseError> {
+    let invalid = || UrlParseError::InvalidOptionValue {
+        option: segment.to_string(),
+        reason: format!("{hex:?} is not a valid hex colour (expected 3 or 6 hex digits)"),
+    };
+
+    // Guard against non-ASCII input before any byte-index slicing below -
+    // `hex.len()` is a byte length, and slicing on a non-char boundary would
+    // panic rather than fall through to the length check.
+    if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(invalid());
+    }
+
+    let expand = |c: char| -> Result<u8, UrlParseError> {
+        let digit = c.to_digit(16).ok_or_else(invalid)? as u8;
+        Ok(digit * 16 + digit)
+    };
+
+    match hex.len() {
+        3 => {
+            let mut chars = hex.chars();
+            let r = expand(chars.next().ok_or_else(invalid)?)?;
+            let g = expand(chars.next().ok_or_else(invalid)?)?;
+            let b = expand(chars.next().ok_or_else(invalid)?)?;
+            Ok([r, g, b])
+        }
+        6 => {
+            let channel = |slice: &str| -> Result<u8, UrlParseError> {
+                u8::from_str_radix(slice, 16).map_err(|_| invalid())
+            };
+            Ok([
+                channel(&hex[0..2])?,
+                channel(&hex[2..4])?,
+                channel(&hex[4..6])?,
+            ])
+        }
+        _ => Err(invalid()),
     }
 }
 
@@ -246,9 +324,15 @@ mod tests {
 
     #[test]
     fn combines_multiple_options() {
-        let opts =
-            ProcessingOptions::parse(&["rs:fill:300:300", "q:80", "bl:5", "g:true", "el:1"])
-                .unwrap();
+        let opts = ProcessingOptions::parse(&[
+            "rs:fill:300:300",
+            "q:80",
+            "bl:5",
+            "g:true",
+            "el:1",
+            "bg:255:0:0",
+        ])
+        .unwrap();
         assert_eq!(opts.width, Some(300));
         assert_eq!(opts.height, Some(300));
         assert_eq!(opts.resize_type, ResizeType::Fill);
@@ -256,6 +340,66 @@ mod tests {
         assert_eq!(opts.blur_sigma, Some(5.0));
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));
+        assert_eq!(opts.background, Some([255, 0, 0]));
+    }
+
+    #[test]
+    fn parses_background_as_rgb_triple() {
+        let opts = ProcessingOptions::parse(&["bg:255:128:0"]).unwrap();
+        assert_eq!(opts.background, Some([255, 128, 0]));
+    }
+
+    #[test]
+    fn parses_background_as_six_digit_hex() {
+        let opts = ProcessingOptions::parse(&["bg:ff8000"]).unwrap();
+        assert_eq!(opts.background, Some([255, 128, 0]));
+    }
+
+    #[test]
+    fn parses_background_as_six_digit_hex_uppercase() {
+        let opts = ProcessingOptions::parse(&["bg:FF8000"]).unwrap();
+        assert_eq!(opts.background, Some([255, 128, 0]));
+    }
+
+    #[test]
+    fn parses_background_as_three_digit_hex_shorthand() {
+        // `f80` expands digit-doubled to `ff8800`, imgproxy/CSS shorthand
+        // convention.
+        let opts = ProcessingOptions::parse(&["bg:f80"]).unwrap();
+        assert_eq!(opts.background, Some([255, 136, 0]));
+    }
+
+    #[test]
+    fn background_defaults_to_none_when_absent() {
+        let opts = ProcessingOptions::parse(&[]).unwrap();
+        assert_eq!(opts.background, None);
+    }
+
+    #[test]
+    fn background_rgb_out_of_range_is_rejected() {
+        assert!(ProcessingOptions::parse(&["bg:256:0:0"]).is_err());
+    }
+
+    #[test]
+    fn background_invalid_hex_is_rejected() {
+        assert!(ProcessingOptions::parse(&["bg:zzzzzz"]).is_err());
+        assert!(ProcessingOptions::parse(&["bg:ff"]).is_err());
+        assert!(ProcessingOptions::parse(&["bg:1234567"]).is_err());
+    }
+
+    #[test]
+    fn background_wrong_argument_count_is_rejected() {
+        assert!(ProcessingOptions::parse(&["bg:1:2"]).is_err());
+        assert!(ProcessingOptions::parse(&["bg:1:2:3:4"]).is_err());
+        assert!(ProcessingOptions::parse(&["bg"]).is_err());
+    }
+
+    #[test]
+    fn background_rejects_non_ascii_without_panicking() {
+        // A multi-byte UTF-8 character here must not panic on byte-index
+        // slicing inside `parse_hex_color` - it should just be rejected.
+        assert!(ProcessingOptions::parse(&["bg:é"]).is_err());
+        assert!(ProcessingOptions::parse(&["bg:ééé"]).is_err());
     }
 
     #[test]

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -24,8 +24,14 @@ use sha2::{Digest, Sha256};
 /// output cached under the same width/height/etc, or vice versa - exactly
 /// the kind of stale, wrong-shape response #59 exists to eliminate. Every
 /// key computed under v3 must therefore be invalidated by this bump, same
-/// as the v2 -> v3 transition for `enlarge`.
-const CACHE_KEY_VERSION: u8 = 4;
+/// as the v2 -> v3 transition for `enlarge`. v5 adds `background` (#34/#60):
+/// before this, the resize pipeline never flattened alpha or normalised
+/// transparent pixels at all, so `background` had no effect on output
+/// bytes. Now that it changes what gets encoded - both the flatten colour
+/// for alpha->no-alpha conversions and the fill colour for fully-transparent
+/// pixels when alpha is kept - two requests differing only in `background`
+/// must not collide onto a v4 key that never hashed it.
+const CACHE_KEY_VERSION: u8 = 5;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -98,6 +104,16 @@ impl CacheService {
         // Always-present (not `Option<bool>`, so no "None" bucket needed
         // here unlike `grayscale`/`blur_sigma`).
         Self::update_field(&mut hasher, params.enlarge.to_string().as_bytes());
+
+        // `background` (#34/#60, v5) changes the resize pipeline's output
+        // bytes wherever alpha is flattened or transparent pixels are
+        // normalised, so it must be part of the key like every other
+        // output-affecting field - see the v5 `CACHE_KEY_VERSION` note
+        // above.
+        match params.background {
+            Some([r, g, b]) => Self::update_field(&mut hasher, &[r, g, b]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
 
         let result = hasher.finalize();
         format!("{:}{:x}.{}", self.minio_sub_path, result, params.format)
@@ -176,6 +192,7 @@ mod tests {
             grayscale,
             enlarge,
             quality: None,
+            background: None,
         }
     }
 
@@ -324,6 +341,39 @@ mod tests {
         );
     }
 
+    /// #34/#60 (v5 bump): `background` changes the resize pipeline's output
+    /// bytes (flatten/normalise colour), so distinct backgrounds - and the
+    /// unset ("use the default") case - must not collide onto the same
+    /// cache key.
+    #[test]
+    fn background_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |background: Option<[u8; 3]>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            background,
+        };
+
+        let keys: HashSet<String> = [None, Some([255, 255, 255]), Some([0, 0, 0]), Some([1, 2, 3])]
+            .into_iter()
+            .map(|bg| cache.generate_key(&base(bg)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            4,
+            "each distinct background (including unset) must produce a distinct cache key"
+        );
+    }
+
     /// #59 (v4 bump): before #59, `fit`/`fill`/`force`/`auto` were parsed
     /// but ignored, so every width+height request resized identically and
     /// `resize_type` didn't need to be part of the key. Now that each type
@@ -346,6 +396,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         };
 
         let keys: HashSet<String> = [

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -29,6 +29,19 @@ use url::Url;
 /// could silently drift from it.
 pub const DEFAULT_WEBP_QUALITY: f32 = 82.0;
 
+/// Default background colour (#34) used both to flatten alpha before
+/// encoding to a format with no alpha channel, and as the fill colour for
+/// fully-transparent pixels when the output format keeps alpha (#60), when
+/// `ResizeQuery::background` (the `bg:` processing option) isn't set.
+///
+/// Deliberately opaque white rather than imgproxy's own default of
+/// "disabled" (no flattening at all unless `bg:` is given) - this crate
+/// always flattens/normalises rather than treating it as opt-in, since a
+/// bare PNG-with-transparency -> JPEG conversion with no explicit `bg:`
+/// should still produce a sane image instead of the undefined-RGB fringing
+/// #34 exists to fix.
+pub const DEFAULT_BACKGROUND: [u8; 3] = [255, 255, 255];
+
 #[derive(Clone, Builder)]
 pub struct ImageService {
     // Limit concurrent downloads to prevent memory exhaustion
@@ -499,15 +512,72 @@ impl ImageService {
             crate::models::params::ImageFormat::Webp => (ImageFormat::WebP, "image/webp"),
         };
 
+        // Alpha handling (#34/#60). Gated on `img.has_alpha()` so a source
+        // that never carried an alpha channel (the common case) pays zero
+        // extra cost - there's nothing to flatten or normalise.
+        let img = if img.has_alpha() {
+            let background = params.background.unwrap_or(DEFAULT_BACKGROUND);
+            match output_format {
+                // JPEG has no alpha channel - flatten (composite) onto
+                // `background` explicitly instead of letting the encoder's
+                // own to_rgb8() conversion drop the channel outright
+                // (`cast_in_color_space`, a raw channel drop, not a
+                // composite - see #34's issue body for the exact vendored
+                // code path this replaces). Without this, transparent
+                // pixels whose RGB was never meaningful (undefined/garbage
+                // under alpha=0) show up as visible fringing instead of a
+                // clean edge against the configured background.
+                ImageFormat::Jpeg => Self::flatten_onto_background(&img, background),
+                // PNG/WebP keep their alpha channel, so this is not a
+                // flatten - but a fully-transparent pixel's RGB is
+                // invisible by definition, and the source frequently
+                // carries undefined/noisy values there that cost real
+                // encoded bytes for a region nobody can see (#60).
+                // Normalising just those pixels to a constant lets
+                // DEFLATE/VP8L collapse the region instead. Only exactly
+                // `alpha == 0` pixels are touched - partial transparency is
+                // visibly blended with whatever is behind it, so rewriting
+                // its RGB would be a real (lossy) visual change, not the
+                // lossless one this is meant to be.
+                _ => DynamicImage::ImageRgba8(Self::normalize_transparent_pixels(
+                    img.to_rgba8(),
+                    background,
+                )),
+            }
+        } else {
+            img
+        };
+
         // WebP goes through the dedicated `webp` crate (`Self::encode_webp`),
         // not `DynamicImage::write_to` - the `image` crate's own WebP
         // encoder (`image-webp`, pulled in via the `webp` cargo feature) is
         // lossless-only, which produced far larger output than intended.
-        // JPEG/PNG are unaffected and keep going through `write_to` exactly
-        // as before.
+        // PNG uses an explicit `PngEncoder` (rather than `write_to`'s
+        // default) to pick `CompressionType::Best` over the crate's own
+        // default of `Fast` (`image-0.25.10/src/codecs/png.rs`,
+        // `CompressionType::default()`) - a real, dependency-free size win
+        // for #60 that doesn't touch `Cargo.toml`: `PngEncoder` and its
+        // `CompressionType`/`FilterType` enums are already part of the
+        // `image` crate's own public API under the `png` feature this crate
+        // already depends on, not a new dependency. JPEG is unaffected and
+        // keeps going through `write_to` exactly as before.
         let output_bytes = match output_format {
             ImageFormat::WebP => Self::encode_webp(&img, DEFAULT_WEBP_QUALITY, false)
                 .context(format!("Failed to encode image to {:?}", output_format))?,
+            ImageFormat::Png => {
+                let estimated_size = Self::estimate_output_size(&img, &output_format);
+                let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
+
+                let encoder = image::codecs::png::PngEncoder::new_with_quality(
+                    &mut buf,
+                    image::codecs::png::CompressionType::Best,
+                    image::codecs::png::FilterType::Adaptive,
+                );
+                img.write_with_encoder(encoder)
+                    .context(format!("Failed to encode image to {:?}", output_format))?;
+
+                buf.into_inner()
+            }
             _ => {
                 // Pre-allocate buffer based on estimated size - only
                 // meaningful for the `write_to` path below; the WebP path
@@ -523,6 +593,72 @@ impl ImageService {
         };
 
         Ok((output_bytes, content_type.to_string()))
+    }
+
+    /// Composites `img` onto an opaque `background` colour, producing a
+    /// plain RGB image with no alpha channel at all (#34). Only meaningful
+    /// as a pre-encode step for a format with no alpha channel (JPEG) - see
+    /// the call site's comment for why this exists instead of letting the
+    /// encoder itself drop the channel.
+    ///
+    /// Standard "over" alpha compositing per channel:
+    /// `out = src * alpha + background * (1 - alpha)`, computed in floating
+    /// point and rounded (not truncated) so a fully-opaque source pixel
+    /// (`alpha == 255`) round-trips to itself exactly, and the `alpha == 0`
+    /// case is special-cased to exactly `background` rather than relying on
+    /// the general formula to reduce to it (it does, but the special case
+    /// avoids float rounding surprises on the boundary the golden-image
+    /// tests assert pixel-exact equality against).
+    fn flatten_onto_background(img: &DynamicImage, background: [u8; 3]) -> DynamicImage {
+        let rgba = img.to_rgba8();
+        let mut out = image::RgbImage::new(rgba.width(), rgba.height());
+
+        for (src, dst) in rgba.pixels().zip(out.pixels_mut()) {
+            let [r, g, b, a] = src.0;
+            *dst = image::Rgb(match a {
+                255 => [r, g, b],
+                0 => background,
+                _ => {
+                    let alpha = f32::from(a) / 255.0;
+                    let blend = |c: u8, bg: u8| -> u8 {
+                        (f32::from(c) * alpha + f32::from(bg) * (1.0 - alpha)).round() as u8
+                    };
+                    [
+                        blend(r, background[0]),
+                        blend(g, background[1]),
+                        blend(b, background[2]),
+                    ]
+                }
+            });
+        }
+
+        DynamicImage::ImageRgb8(out)
+    }
+
+    /// Rewrites the RGB of every fully-transparent (`alpha == 0`) pixel to
+    /// `background`, leaving every other pixel - including partially
+    /// transparent ones - byte-for-byte untouched (#60).
+    ///
+    /// Safe by construction: a pixel with `alpha == 0` is invisible
+    /// regardless of its RGB, so this cannot change what any viewer sees -
+    /// only what bytes the encoder has to spend compressing an invisible
+    /// region (a solid-colour region compresses far better than whatever
+    /// noise the source had there). Partial transparency is deliberately
+    /// left alone: its RGB is visible (blended with whatever ends up
+    /// behind it), so rewriting it would be a real, lossy visual change,
+    /// not the lossless one this is meant to be.
+    fn normalize_transparent_pixels(
+        mut rgba: image::RgbaImage,
+        background: [u8; 3],
+    ) -> image::RgbaImage {
+        for pixel in rgba.pixels_mut() {
+            if pixel.0[3] == 0 {
+                pixel.0[0] = background[0];
+                pixel.0[1] = background[1];
+                pixel.0[2] = background[2];
+            }
+        }
+        rgba
     }
 
     /// Encodes `img` to WebP via the `webp` crate directly (libwebp
@@ -746,6 +882,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         }
     }
 
@@ -1642,5 +1779,211 @@ mod tests {
         );
 
         server.abort();
+    }
+
+    // ---- #34/#60: alpha flattening and transparent-pixel normalisation ----
+
+    /// Builds a `ResizeQuery` requesting no resize at all (keeps the
+    /// fixture's original pixel grid so boundary assertions below land on
+    /// exact, known pixel coordinates instead of whatever a resize filter's
+    /// interpolation produces near the edge) with the given output format
+    /// and `background`.
+    fn query_for_alpha(format: ApiImageFormat, background: Option<[u8; 3]>) -> ResizeQuery {
+        ResizeQuery {
+            url: "https://images.example.com/alpha.png".to_string(),
+            width: None,
+            height: None,
+            resize_type: ResizeType::Fit,
+            format,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            background,
+        }
+    }
+
+    /// #34: pure unit test of the compositing formula itself, independent
+    /// of any lossy encoding - `alpha == 255` must reproduce the source
+    /// exactly, `alpha == 0` must land exactly on `background` (not
+    /// whatever garbage RGB the source carried there), and partial
+    /// transparency must genuinely blend rather than equal either input.
+    #[test]
+    fn flatten_onto_background_composites_alpha_correctly() {
+        let mut img = image::RgbaImage::new(1, 3);
+        img.put_pixel(0, 0, image::Rgba([10, 20, 30, 255])); // opaque
+        img.put_pixel(0, 1, image::Rgba([10, 20, 30, 0])); // fully transparent, garbage rgb
+        img.put_pixel(0, 2, image::Rgba([0, 0, 0, 128])); // ~50% transparent, black
+
+        let dynamic = DynamicImage::ImageRgba8(img);
+        let background = [255, 255, 255];
+        let flattened = ImageService::flatten_onto_background(&dynamic, background).to_rgb8();
+
+        assert_eq!(
+            flattened.get_pixel(0, 0).0,
+            [10, 20, 30],
+            "opaque pixel must pass through unchanged"
+        );
+        assert_eq!(
+            flattened.get_pixel(0, 1).0,
+            background,
+            "fully transparent pixel must land exactly on the background, not its garbage RGB"
+        );
+
+        let blended = flattened.get_pixel(0, 2).0;
+        assert_ne!(blended, [0, 0, 0], "must not equal the source colour");
+        assert_ne!(blended, background, "must not equal the background either");
+        // alpha = 128/255 ~= 0.502; out = 0*0.502 + 255*0.498 ~= 127.
+        for channel in blended {
+            assert!(
+                (120..=135).contains(&channel),
+                "expected the 50%-alpha blend near 127, got {blended:?}"
+            );
+        }
+    }
+
+    /// #60: only pixels with exactly `alpha == 0` are rewritten - partial
+    /// transparency and full opacity must be byte-for-byte untouched, since
+    /// their RGB is actually visible (blended with whatever is behind them
+    /// for partial alpha, directly for opaque).
+    #[test]
+    fn normalize_transparent_pixels_only_rewrites_fully_transparent_pixels() {
+        let mut img = image::RgbaImage::new(1, 3);
+        img.put_pixel(0, 0, image::Rgba([10, 20, 30, 255])); // opaque
+        img.put_pixel(0, 1, image::Rgba([99, 88, 77, 0])); // fully transparent, garbage rgb
+        img.put_pixel(0, 2, image::Rgba([1, 2, 3, 128])); // partial
+
+        let background = [255, 0, 0];
+        let normalized = ImageService::normalize_transparent_pixels(img, background);
+
+        assert_eq!(normalized.get_pixel(0, 0).0, [10, 20, 30, 255]);
+        assert_eq!(
+            normalized.get_pixel(0, 1).0,
+            [background[0], background[1], background[2], 0],
+            "fully transparent pixel's RGB must be rewritten to the background, alpha unchanged"
+        );
+        assert_eq!(
+            normalized.get_pixel(0, 2).0,
+            [1, 2, 3, 128],
+            "partially transparent pixel must be left byte-for-byte untouched"
+        );
+    }
+
+    /// #34: the alpha fixture (`fixtures::alpha`, mirrored by
+    /// `bench-imgproxy/fixtures/generate.py`'s `alpha_fringe_rgba`) has a
+    /// transparent border with deliberately garbage (non-zero) RGB
+    /// underneath - exactly the vendored `to_rgb8()` raw-channel-drop bug
+    /// the issue's source citation identified. Converting it to JPEG (no
+    /// alpha channel) must flatten that border onto the default background
+    /// (white, since `background` is `None` here) instead of letting the
+    /// garbage show through. Golden-image style: asserts actual decoded
+    /// pixel values at the boundary, not just a successful conversion.
+    #[test]
+    fn alpha_fixture_flattens_to_default_white_background_when_converted_to_jpeg() {
+        let bytes = fixtures::alpha(); // 512x512, border width 32px
+        let config = PerformanceConfig::default();
+        let params = query_for_alpha(ApiImageFormat::Jpg, None);
+
+        let (output, content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+        assert_eq!(content_type, "image/jpeg");
+
+        let decoded = image::load_from_memory_with_format(&output, ImageFormat::Jpeg)
+            .expect("output should decode")
+            .to_rgb8();
+
+        // (0, 0) is deep inside the transparent border - garbage RGB
+        // pre-fix, must be near-white post-fix (JPEG is lossy, so allow a
+        // small tolerance rather than requiring exactly 255).
+        let pixel = decoded.get_pixel(0, 0).0;
+        for (channel, value) in ["r", "g", "b"].into_iter().zip(pixel) {
+            assert!(
+                value > 235,
+                "expected boundary pixel channel {channel} near white (255), got {value} \
+                 (full pixel: {pixel:?})"
+            );
+        }
+    }
+
+    /// #34: a caller-supplied `background` (the `bg:` processing option)
+    /// must be honoured instead of the default white - proven against the
+    /// same boundary pixel as the default-background test above.
+    #[test]
+    fn custom_background_is_honoured_when_flattening_to_jpeg() {
+        let bytes = fixtures::alpha();
+        let config = PerformanceConfig::default();
+        let params = query_for_alpha(ApiImageFormat::Jpg, Some([0, 0, 255])); // pure blue
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let decoded = image::load_from_memory_with_format(&output, ImageFormat::Jpeg)
+            .expect("output should decode")
+            .to_rgb8();
+
+        let [r, g, b] = decoded.get_pixel(0, 0).0;
+        assert!(r < 40, "expected low red near a blue background, got {r}");
+        assert!(g < 40, "expected low green near a blue background, got {g}");
+        assert!(b > 200, "expected high blue near a blue background, got {b}");
+    }
+
+    /// #60: output-size regression guard for the exact adversarial shape
+    /// the issue measured. Pre-fix, the analogous corpus fixture
+    /// (`bench-imgproxy/fixtures/corpus/alpha_1024.png`, same generator,
+    /// same seed - see `bench-imgproxy/fixtures/generate.py`) encoded to
+    /// PNG at `fill:400:300` measured 85,347 bytes. Post-fix, the in-repo
+    /// 512px fixture at the same request measures 11,337 bytes - the
+    /// 25,000-byte threshold asserted here gives ~2.2x headroom over that
+    /// measurement (so the assertion isn't flaky against encoder-internals
+    /// drift) while staying well under an order of magnitude below the
+    /// pre-fix floor, so a regression that turns normalisation back into a
+    /// no-op is still caught.
+    #[test]
+    fn alpha_fixture_encoded_to_png_stays_under_size_threshold() {
+        let bytes = fixtures::alpha();
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Png,
+            ..query_with_type(Some(400), Some(300), ResizeType::Fill)
+        };
+
+        let (output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            output.len() < 25_000,
+            "expected normalised alpha PNG under 25,000 bytes, got {} \
+             (pre-fix, the analogous corpus fixture measured 85,347 bytes)",
+            output.len()
+        );
+    }
+
+    /// #60 (the non-adversarial case the issue explicitly calls out): a
+    /// flat/solid-colour PNG has no transparency at all, so this exercises
+    /// only the `CompressionType::Best` PNG-encoder change, not
+    /// flattening/normalisation. Measured 2,596 -> 1,063 bytes for the
+    /// analogous 1024px corpus fixture; asserted here against the in-repo
+    /// fixture with headroom.
+    #[test]
+    fn flat_colour_png_benefits_from_best_compression() {
+        let bytes = fixtures::flat();
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Png,
+            ..query_with_type(Some(400), Some(300), ResizeType::Fill)
+        };
+
+        let (output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            output.len() < 3_000,
+            "expected flat-colour PNG under 3,000 bytes with Best compression, got {}",
+            output.len()
+        );
     }
 }

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -497,6 +497,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         });
 
         let mut handles = Vec::with_capacity(100);
@@ -573,6 +574,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         });
 
         let mut handles = Vec::with_capacity(20);

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -468,6 +468,7 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            background: None,
         };
         let key = cache.generate_key(&params);
         assert!(


### PR DESCRIPTION
## Summary

Neither issue was really about JPEG or PNG. The image handler had **no alpha handling at any stage** — grepping it for `alpha`, `background`, `flatten` or `premultipl` returned nothing. Two symptoms, one gap.

Closes #34, #60.

## What was wrong

**#34** — encoding to JPEG went through `to_rgb8()`, a raw channel drop rather than a composite. Previously-transparent regions rendered as whatever undefined RGB happened to sit underneath.

**#60** — formats that *keep* alpha carried that same undefined RGB straight into the encoder, where it costs full entropy. Noise does not compress.

## Results, measured against imgproxy v4.0.13 (fill 400x300)

| source | format | before | after | imgproxy | ratio |
|---|---|---:|---:|---:|---|
| alpha RGBA | png | 85,347 | **12,942** | 2,262 | 37.7x → **5.72x** |
| alpha RGBA | jpg | 17,368 | **8,948** | 5,066 | 3.43x → **1.77x** |
| alpha RGBA | webp | 3,824 | **3,166** | 1,904 | 2.01x → **1.66x** |
| flat colour | png | 2,596 | **1,063** | 1,280 | 2.03x → **0.83x — emgr now smaller** |
| photo | jpg / webp | unchanged | unchanged | — | no alpha, stage never runs |

## What this does NOT fix — read this before quoting the table

**The flat-colour JPEG gap (3.37x) is deliberately untouched.** That fixture has no alpha channel, so the new stage never runs on it. It is a JPEG encoder-settings difference and needs separate work. It must not be read as part of this fix.

Also: the 37x headline came from an **adversarially constructed** fixture — `bench-imgproxy/fixtures/generate.py` puts garbage RGB under transparency specifically to exercise #34. The honest signal is the flat-colour PNG row, which uses an ordinary image and went from 2.03x worse to 0.83x better.

## Correctness of the normalisation

Only pixels with **exactly `alpha == 0`** are rewritten. Those are invisible by definition, so replacing their RGB is lossless. Partial transparency genuinely contributes colour and is left to composite normally — rewriting it would trade a size bug for a visual one.

Compositing is `out = src*a + bg*(1-a)` in floating point with rounding, so a fully-opaque source pixel round-trips to itself exactly.

## Also

- New `bg:{R}:{G}:{B}` and `bg:{hex}` options, defaulting to opaque white.
- PNG moved from the crate default `CompressionType::Fast` to `Best` with adaptive filtering — public API, **no new dependency**.
- `CACHE_KEY_VERSION` 4 → 5: existing entries predate flattening and would otherwise be served unflattened.
- Palettisation was **not** attempted — the viable route needs a `Cargo.toml` dependency, so it was left as follow-up rather than done unilaterally. That is likely most of the remaining 5.72x on the alpha PNG case.

## Verification

- `cargo check --features local_fs --bins --tests --benches` — 0 errors
- `cargo check --features s3` — 0 errors
- `cargo test --features local_fs` — **385 passed, 0 failed** (was 362)
- Golden-pixel tests assert the actual boundary pixel value after flattening, not just a 200
- Output-size regression guards so this cannot silently regress

## Unrelated finding worth recording

Re-running the encode benchmarks against the committed baseline:

```
                 baseline    now
encode/jpeg      3.19 ms     2.90 ms
encode/png       2.09 ms     1.65 ms
encode/webp      2.25 ms    23.00 ms    <- 10x slower
```

That WebP figure is **not from this PR** — it is the cost of #32's switch from lossless VP8L to lossy libwebp. It buys the 14-16% size reduction measured in `adr/0003`. Recording it because it was never measured at the time and it materially affects WebP throughput.

## Reviewer focus

1. **The `alpha == 0` boundary** in `normalize_transparent_pixels` — the correctness of the whole size win rests on it being strictly fully-transparent.
2. **The compositing rounding** — opaque pixels must round-trip exactly.
3. **The cache-key bump** — without it, cached pre-flatten entries keep serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
