### PR TITLE
feat: quality, per-format quality and lossless WebP (#35, #4)

### DIFF
--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -22,6 +22,9 @@ fn bench_cache_key(c: &mut Criterion) {
         grayscale: Some(false),
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     };
 

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -24,6 +24,9 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         grayscale: None,
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     }
 }

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -137,10 +137,35 @@ pub struct ResizeQuery {
     pub enlarge: bool,
 
     /// Output encode quality (imgproxy's `q:{0-100}` processing option).
-    /// `None` lets the encoder pick its own default. Threaded through for
-    /// the concurrently-landing lossy-WebP encoding work
-    /// (`src/services/image/handler.rs`, owned by another agent).
+    /// `None` lets the encoder pick its own default
+    /// (`ImageService::DEFAULT_JPEG_QUALITY` / `DEFAULT_WEBP_QUALITY`,
+    /// `src/services/image/handler.rs`). Overridden per-format by
+    /// `jpeg_quality`/`webp_quality` below when those are set (#35) -
+    /// mirrors imgproxy's own `q` (global) vs `format_quality` (per-format)
+    /// precedence (<https://docs.imgproxy.net/usage/processing#quality>).
     pub quality: Option<u8>,
+
+    /// Per-format quality override (imgproxy's `format_quality`/`fq:{format}:
+    /// {quality}:...` processing option, #35). Takes precedence over
+    /// `quality` for JPEG output when set - see
+    /// `ImageService::process_image_blocking_with_limits`
+    /// (`src/services/image/handler.rs`) for the exact precedence.
+    pub jpeg_quality: Option<u8>,
+
+    /// Per-format quality override for WebP output - see `jpeg_quality`
+    /// above for the general shape; same precedence over `quality`.
+    pub webp_quality: Option<u8>,
+
+    /// Encode WebP losslessly instead of lossily (imgproxy's `webp_options`/
+    /// `webpo:{compression}` processing option, #35 - only the `compression`
+    /// slot is implemented, see [`crate::modules::url::options`] for why).
+    /// `None`/`Some(false)` keeps the existing lossy path
+    /// (`ImageService::encode_webp`'s `lossless` parameter); `Some(true)`
+    /// encodes losslessly and ignores `quality`/`webp_quality` entirely,
+    /// matching `encode_webp`'s own "quality is used only when lossless is
+    /// false" contract. Meaningless (silently ignored) for non-WebP output,
+    /// same as every other format-specific option in this struct.
+    pub webp_lossless: Option<bool>,
 
     /// Background colour, as an `[R, G, B]` triple (imgproxy's
     /// `background`/`bg:{R}:{G}:{B}` or `bg:{hex}` processing option, #34).

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -271,6 +271,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -114,6 +114,9 @@ impl ParsedRequest {
             grayscale: self.options.grayscale,
             enlarge: self.options.enlarge.unwrap_or(false),
             quality: self.options.quality,
+            jpeg_quality: self.options.jpeg_quality,
+            webp_quality: self.options.webp_quality,
+            webp_lossless: self.options.webp_lossless,
             background: self.options.background,
         }
     }
@@ -152,8 +155,9 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
-        let path =
-            format!("/SIG/rs:fill:300:300/q:80/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp");
+        let path = format!(
+            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp"
+        );
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
         let query = parsed.into_resize_query();
@@ -163,6 +167,9 @@ mod tests {
         assert_eq!(query.height, Some(300));
         assert_eq!(query.resize_type, crate::models::params::ResizeType::Fill);
         assert_eq!(query.quality, Some(80));
+        assert_eq!(query.webp_quality, Some(90));
+        assert_eq!(query.webp_lossless, Some(true));
+        assert_eq!(query.jpeg_quality, None);
         assert_eq!(query.blur_sigma, Some(5.0));
         assert_eq!(query.grayscale, Some(true));
         assert!(query.enlarge);
@@ -184,6 +191,9 @@ mod tests {
             crate::models::params::ResizeType::default()
         );
         assert_eq!(query.quality, None);
+        assert_eq!(query.jpeg_quality, None);
+        assert_eq!(query.webp_quality, None);
+        assert_eq!(query.webp_lossless, None);
         assert_eq!(query.blur_sigma, None);
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -6,8 +6,9 @@ use crate::models::params::ResizeType;
 /// own short option codes (`rs`, `q`, `bl`, `g`, `el`) so a client library
 /// written for imgproxy's URL format produces something this parser accepts
 /// for the capability set #53 keeps: width, height, resize type, blur,
-/// grayscale, enlarge, quality (format comes from the trailing
-/// `.{extension}` instead - see [`super::source`]).
+/// grayscale, enlarge, quality, per-format quality override, webp lossless
+/// (format comes from the trailing `.{extension}` instead - see
+/// [`super::source`]).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ProcessingOptions {
     pub width: Option<u32>,
@@ -21,6 +22,15 @@ pub struct ProcessingOptions {
     pub grayscale: Option<bool>,
     pub enlarge: Option<bool>,
     pub quality: Option<u8>,
+    /// `fq`'s parsed `jpg`/`jpeg` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::jpeg_quality`].
+    pub jpeg_quality: Option<u8>,
+    /// `fq`'s parsed `webp` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_quality`].
+    pub webp_quality: Option<u8>,
+    /// `webpo`'s parsed `compression` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_lossless`].
+    pub webp_lossless: Option<bool>,
     /// `bg`'s parsed `[R, G, B]` triple (#34) - see
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
@@ -66,6 +76,81 @@ impl ProcessingOptions {
                 "q" => {
                     let [value] = require_args::<1>(&args, segment)?;
                     opts.quality = Some(parse_bounded(value, segment, 0, 100)?);
+                }
+                // fq:{format1}:{quality1}:{format2}:{quality2}:... - imgproxy's
+                // `format_quality`/`fq` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#format-quality>):
+                // "adds or redefines format_quality values" for the current
+                // request, on top of `q`'s global default. Only `jpg`/`jpeg`
+                // and `webp` are accepted - PNG output always uses this
+                // crate's fixed `CompressionType::Best` (no continuous 0-100
+                // quality knob exists to override), so `fq:png:N` is rejected
+                // with 400 rather than silently ignored. Repeating a format
+                // (`fq:jpg:80:jpg:90`) lets the later pair win, same as
+                // imgproxy's own "redefines" wording implies.
+                "fq" => {
+                    if args.is_empty() || !args.len().is_multiple_of(2) {
+                        return Err(UrlParseError::InvalidOptionValue {
+                            option: segment.to_string(),
+                            reason: "expected one or more format:quality pairs".to_string(),
+                        });
+                    }
+                    for pair in args.chunks(2) {
+                        let (format, value) = (pair[0], pair[1]);
+                        let quality = parse_bounded(value, segment, 0, 100)?;
+                        match format {
+                            "jpg" | "jpeg" => opts.jpeg_quality = Some(quality),
+                            "webp" => opts.webp_quality = Some(quality),
+                            "png" => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: "png has no adjustable quality in this encoder \
+                                             (PNG output always uses fixed CompressionType::Best)"
+                                        .to_string(),
+                                });
+                            }
+                            other => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: format!(
+                                        "unsupported format {other:?} for format_quality \
+                                         (expected jpg, jpeg or webp)"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                // webpo:{compression} - a deliberately partial implementation
+                // of imgproxy's `webp_options`/`webpo:{compression}:
+                // {smart_subsample}:{preset}` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#webp-options>).
+                // Only the `compression` slot is implemented - the `webp`
+                // crate (0.3.1) this project depends on exposes exactly two
+                // encode modes, `Encoder::encode` (lossy) and
+                // `Encoder::encode_lossless`, with no `smart_subsample` or
+                // `preset` knob at all, and no `mixed` mode either. Requiring
+                // exactly one argument (rather than silently accepting and
+                // ignoring imgproxy's other two slots) is deliberate: a
+                // caller who actually needs `smart_subsample`/`preset` gets a
+                // clear 400 here instead of a silently-ignored parameter.
+                "webpo" => {
+                    let [compression] = require_args::<1>(&args, segment)?;
+                    opts.webp_lossless = Some(match compression {
+                        "lossy" => false,
+                        "lossless" => true,
+                        other => {
+                            return Err(UrlParseError::InvalidOptionValue {
+                                option: segment.to_string(),
+                                reason: format!(
+                                    "{other:?} is not a supported webp compression mode \
+                                     (expected lossy or lossless - this encoder has no \
+                                     mixed mode, and does not support imgproxy's \
+                                     smart_subsample/preset slots)"
+                                ),
+                            });
+                        }
+                    });
                 }
                 "bl" => {
                     let [value] = require_args::<1>(&args, segment)?;
@@ -285,6 +370,81 @@ mod tests {
     }
 
     #[test]
+    fn parses_format_quality_for_jpeg_and_webp() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:webp:90"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+    }
+
+    #[test]
+    fn format_quality_accepts_jpeg_alias() {
+        let opts = ProcessingOptions::parse(&["fq:jpeg:70"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(70));
+    }
+
+    #[test]
+    fn format_quality_later_pair_overrides_earlier_for_same_format() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:jpg:40"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(40));
+    }
+
+    #[test]
+    fn format_quality_rejects_png() {
+        assert!(ProcessingOptions::parse(&["fq:png:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_unknown_format() {
+        assert!(ProcessingOptions::parse(&["fq:avif:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_odd_argument_count() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:80:webp"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_out_of_range_value() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:101"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_empty_args() {
+        assert!(ProcessingOptions::parse(&["fq"]).is_err());
+    }
+
+    #[test]
+    fn parses_webp_lossless() {
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossless"])
+                .unwrap()
+                .webp_lossless,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossy"])
+                .unwrap()
+                .webp_lossless,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn webp_lossless_rejects_unsupported_mode() {
+        assert!(ProcessingOptions::parse(&["webpo:mixed"]).is_err());
+        assert!(ProcessingOptions::parse(&["webpo:nope"]).is_err());
+    }
+
+    #[test]
+    fn webp_lossless_rejects_extra_arguments() {
+        // imgproxy's own 3-slot grammar (compression:smart_subsample:preset)
+        // - this crate only implements the first slot, and rejects rather
+        // than silently ignoring the other two (see the `webpo` match arm's
+        // doc comment).
+        assert!(ProcessingOptions::parse(&["webpo:lossless::4"]).is_err());
+    }
+
+    #[test]
     fn parses_blur() {
         let opts = ProcessingOptions::parse(&["bl:5"]).unwrap();
         assert_eq!(opts.blur_sigma, Some(5.0));
@@ -327,6 +487,8 @@ mod tests {
         let opts = ProcessingOptions::parse(&[
             "rs:fill:300:300",
             "q:80",
+            "fq:webp:90",
+            "webpo:lossless",
             "bl:5",
             "g:true",
             "el:1",
@@ -337,6 +499,8 @@ mod tests {
         assert_eq!(opts.height, Some(300));
         assert_eq!(opts.resize_type, ResizeType::Fill);
         assert_eq!(opts.quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+        assert_eq!(opts.webp_lossless, Some(true));
         assert_eq!(opts.blur_sigma, Some(5.0));
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -30,8 +30,17 @@ use sha2::{Digest, Sha256};
 /// bytes. Now that it changes what gets encoded - both the flatten colour
 /// for alpha->no-alpha conversions and the fill colour for fully-transparent
 /// pixels when alpha is kept - two requests differing only in `background`
-/// must not collide onto a v4 key that never hashed it.
-const CACHE_KEY_VERSION: u8 = 5;
+/// must not collide onto a v4 key that never hashed it. v6 adds `quality`,
+/// `jpeg_quality`, `webp_quality` and `webp_lossless` (#35): `quality` was
+/// already parsed into `ResizeQuery` (from the URL grammar's `q:{0-100}`)
+/// before this change, but was never fed into `generate_key` at all - a
+/// pure oversight, not a deliberate "doesn't affect output" omission like
+/// `resize_type` was pre-#59, since quality has always affected encoded
+/// bytes for whatever encoder actually used it. Now that the encoders in
+/// `src/services/image/handler.rs` honour these fields, two requests
+/// differing only in quality/format-quality/losslessness must not collide
+/// onto a v5 key that never hashed any of them.
+const CACHE_KEY_VERSION: u8 = 6;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -104,6 +113,29 @@ impl CacheService {
         // Always-present (not `Option<bool>`, so no "None" bucket needed
         // here unlike `grayscale`/`blur_sigma`).
         Self::update_field(&mut hasher, params.enlarge.to_string().as_bytes());
+
+        // `quality`/`jpeg_quality`/`webp_quality`/`webp_lossless` (#35, v6)
+        // change the encoder's output bytes directly - see the v6
+        // `CACHE_KEY_VERSION` note above for why these were missing before.
+        match params.quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.jpeg_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_lossless {
+            Some(lossless) => Self::update_field(&mut hasher, lossless.to_string().as_bytes()),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
 
         // `background` (#34/#60, v5) changes the resize pipeline's output
         // bytes wherever alpha is flattened or transparent pixels are
@@ -192,6 +224,9 @@ mod tests {
             grayscale,
             enlarge,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -359,6 +394,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         };
 
@@ -371,6 +409,120 @@ mod tests {
             keys.len(),
             4,
             "each distinct background (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): `quality` changes the encoded output bytes, so
+    /// distinct qualities - and the unset ("use the encoder's default")
+    /// case - must not collide onto the same cache key.
+    #[test]
+    fn quality_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(30), Some(75), Some(90)]
+            .into_iter()
+            .map(|q| cache.generate_key(&base(q)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            4,
+            "each distinct quality (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): a per-format quality override changes the encoded
+    /// output bytes independently of the global `quality`, so it must be
+    /// its own dimension in the cache key rather than being folded into (or
+    /// ignored relative to) `quality`.
+    #[test]
+    fn format_quality_produces_distinct_keys_from_global_quality() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>, jpeg_quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let global_only = cache.generate_key(&base(Some(80), None));
+        let override_only = cache.generate_key(&base(None, Some(80)));
+        let both = cache.generate_key(&base(Some(80), Some(80)));
+        let neither = cache.generate_key(&base(None, None));
+
+        let keys: HashSet<String> = [
+            global_only.clone(),
+            override_only.clone(),
+            both.clone(),
+            neither.clone(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            keys.len(),
+            4,
+            "quality and jpeg_quality must each be an independent cache-key dimension"
+        );
+    }
+
+    /// #35 (v6 bump): `webp_lossless` changes the encoded output bytes
+    /// (an entirely different codec path - `encode_lossless` vs `encode`),
+    /// so it must not collide with the lossy default.
+    #[test]
+    fn webp_lossless_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |webp_lossless: Option<bool>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Webp,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(false), Some(true)]
+            .into_iter()
+            .map(|l| cache.generate_key(&base(l)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct webp_lossless value (including unset) must produce a distinct cache key"
         );
     }
 
@@ -396,6 +548,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
 

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -16,19 +16,31 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use url::Url;
 
-/// Placeholder lossy-WebP encode quality (0.0-100.0, libwebp's own scale).
-/// `ResizeQuery` (`src/models/params.rs`) now carries a real `quality:
-/// Option<u8>` field, parsed from the signed URL grammar's `q:{0-100}`
-/// processing option (#53/#27) - wiring it into the call site below instead
-/// of this placeholder is a one-line change (`ImageService::encode_webp`
-/// already accepts `quality`/`lossless` as plain parameters), just not made
-/// here since it's this file's own call to make. 82.0 is a commonly-cited
-/// "high quality, still meaningfully smaller than lossless" WebP setting.
+/// Default lossy-WebP encode quality (0.0-100.0, libwebp's own scale), used
+/// when neither `ResizeQuery::webp_quality` nor `ResizeQuery::quality` is
+/// set (#35). 82.0 is a commonly-cited "high quality, still meaningfully
+/// smaller than lossless" WebP setting, and is corroborated by
+/// `adr/0003-webp-measurement.md`'s matched-DSSIM sweep against the Kodak
+/// corpus: 82 falls between the measured q80 bucket (median WebP/JPEG size
+/// ratio 0.8497, n=23 images) and q85 bucket (0.8596, n=18), both inside the
+/// flat, no-crossover 40-85 range where WebP is consistently 15-19% smaller
+/// than JPEG at equal perceptual quality. That ADR explicitly re-checked
+/// this constant and requested no change.
 ///
 /// `pub` (like `encode_webp` itself) so `benches/encode.rs` can benchmark
 /// the exact default production uses instead of a hardcoded duplicate that
 /// could silently drift from it.
 pub const DEFAULT_WEBP_QUALITY: f32 = 82.0;
+
+/// Default JPEG encode quality (1-100, the `image` crate's own scale), used
+/// when neither `ResizeQuery::jpeg_quality` nor `ResizeQuery::quality` is
+/// set (#35). Matches `image::codecs::jpeg::JpegEncoder::new`'s own default
+/// (`image-0.25.10/src/codecs/jpeg/encoder.rs:392`, `new_with_quality(w,
+/// 75)`) - this crate's JPEG output already encoded at 75 before #35 (via
+/// `DynamicImage::write_to`'s default encoder construction), just without a
+/// named constant or a way to override it per-request. `adr/0003` measured
+/// against this exact default and requested no change to it either.
+pub const DEFAULT_JPEG_QUALITY: u8 = 75;
 
 /// Default background colour (#34) used both to flatten alpha before
 /// encoding to a format with no alpha channel, and as the fill colour for
@@ -571,11 +583,33 @@ impl ImageService {
         // for #60 that doesn't touch `Cargo.toml`: `PngEncoder` and its
         // `CompressionType`/`FilterType` enums are already part of the
         // `image` crate's own public API under the `png` feature this crate
-        // already depends on, not a new dependency. JPEG is unaffected and
-        // keeps going through `write_to` exactly as before.
+        // already depends on, not a new dependency. JPEG now uses an
+        // explicit `JpegEncoder::new_with_quality` (#35) instead of
+        // `write_to`'s implicit default-quality construction, so
+        // `params.quality`/`params.jpeg_quality` actually reach the encoder.
+        //
+        // PNG has no quality knob in `params` to honour - `CompressionType`
+        // is a fixed lossless setting, not a continuous 0-100 scale, and
+        // `fq:png:N` is rejected at parse time
+        // (`src/modules/url/options.rs`) rather than silently accepted and
+        // ignored here.
         let output_bytes = match output_format {
-            ImageFormat::WebP => Self::encode_webp(&img, DEFAULT_WEBP_QUALITY, false)
-                .context(format!("Failed to encode image to {:?}", output_format))?,
+            ImageFormat::WebP => {
+                let lossless = params.webp_lossless.unwrap_or(false);
+                // `quality` is meaningless (and unused by `encode_webp`)
+                // when `lossless` is set - see that function's own doc
+                // comment - but still resolved unconditionally here since
+                // that's simpler than threading an `Option` through just to
+                // skip computing a value nothing will read.
+                let quality = params
+                    .webp_quality
+                    .or(params.quality)
+                    .map(f32::from)
+                    .unwrap_or(DEFAULT_WEBP_QUALITY);
+
+                Self::encode_webp(&img, quality, lossless)
+                    .context(format!("Failed to encode image to {:?}", output_format))?
+            }
             ImageFormat::Png => {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
@@ -590,18 +624,28 @@ impl ImageService {
 
                 buf.into_inner()
             }
-            _ => {
-                // Pre-allocate buffer based on estimated size - only
-                // meaningful for the `write_to` path below; the WebP path
-                // above gets its output buffer from libwebp itself.
+            ImageFormat::Jpeg => {
+                let quality = params
+                    .jpeg_quality
+                    .or(params.quality)
+                    .unwrap_or(DEFAULT_JPEG_QUALITY);
+
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                img.write_to(&mut buf, output_format)
+                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
                 buf.into_inner()
             }
+            // `output_format` is only ever constructed from `params.format`
+            // (`crate::models::params::ImageFormat`, three variants: `Jpg`,
+            // `Png`, `Webp`) a few lines above, so every value the `match`
+            // above doesn't already handle is unreachable in practice - kept
+            // as a hard error rather than a silent generic `write_to` fallback
+            // so a future fourth format doesn't quietly skip quality handling.
+            other => anyhow::bail!("unsupported output format {other:?}"),
         };
 
         Ok((output_bytes, content_type.to_string()))
@@ -1055,6 +1099,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -1972,6 +2019,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         }
     }
@@ -2157,6 +2207,177 @@ mod tests {
             output.len() < 3_000,
             "expected flat-colour PNG under 3,000 bytes with Best compression, got {}",
             output.len()
+        );
+    }
+
+    // ---- #35: quality wiring (JpegEncoder::new_with_quality, encode_webp's
+    // quality/lossless parameters, per-format override, cache-key coverage
+    // for these tested separately in `src/services/cache/handler.rs`) ----
+
+    /// A lower JPEG quality must always produce a smaller (or equal, but in
+    /// practice smaller for a real photographic fixture) output than a
+    /// higher one, for the same source and dimensions - the whole point of
+    /// exposing the knob at all.
+    #[test]
+    fn jpeg_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Jpg,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// Same monotonicity property as `jpeg_quality_changes_output_size_monotonically`,
+    /// but through the lossy-WebP path (`Self::encode_webp`'s `quality`
+    /// parameter) instead of JPEG's.
+    #[test]
+    fn webp_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Webp,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// `jpeg_quality` (the `fq:jpg:{quality}` per-format override) must win
+    /// over the lower global `quality` - imgproxy's own documented
+    /// precedence for `format_quality` over `quality`.
+    #[test]
+    fn format_quality_override_beats_global_quality() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let global_low = ResizeQuery {
+            quality: Some(30),
+            ..base.clone()
+        };
+        let override_high = ResizeQuery {
+            quality: Some(30),
+            jpeg_quality: Some(90),
+            ..base
+        };
+
+        let (out_global, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &global_low, &config)
+                .expect("processing should succeed");
+        let (out_override, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &override_high, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            out_override.len() > out_global.len(),
+            "expected jpeg_quality=90 ({} bytes) to override the lower global quality=30 \
+             ({} bytes), producing larger output",
+            out_override.len(),
+            out_global.len()
+        );
+    }
+
+    /// Lossless WebP (`webp_lossless: Some(true)`) must round-trip the
+    /// source pixels exactly - no resize/blur/grayscale filter applied, and
+    /// a source with no alpha channel so the #34/#60 flatten/normalise
+    /// stage is a no-op, isolating this to purely the encoder's own
+    /// lossless-ness.
+    #[test]
+    fn webp_lossless_round_trips_byte_identical_pixels() {
+        let bytes = fixtures::photo_like(); // 1920x1080, no alpha channel
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            webp_lossless: Some(true),
+            ..query(None, None)
+        };
+
+        let (output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let original = image::load_from_memory(&bytes)
+            .expect("source should decode")
+            .to_rgba8();
+        let decoded = image::load_from_memory(&output)
+            .expect("lossless webp output should decode")
+            .to_rgba8();
+
+        assert_eq!(decoded.dimensions(), original.dimensions());
+        assert_eq!(
+            decoded.as_raw(),
+            original.as_raw(),
+            "lossless webp round-trip must be byte-identical to the source pixels"
+        );
+    }
+
+    /// Lossless WebP must actually take the `encode_lossless` path, not
+    /// merely happen to look identical - `lossless: Some(false)` (still
+    /// lossy) on the exact same source/dimensions must produce different
+    /// (and, for a real photographic fixture, larger) output, proving the
+    /// flag is wired through rather than a no-op that always round-trips
+    /// because e.g. quality was already 100.
+    #[test]
+    fn webp_lossless_differs_from_lossy_output() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            ..query(Some(400), Some(300))
+        };
+
+        let lossy = ResizeQuery {
+            webp_lossless: Some(false),
+            ..base.clone()
+        };
+        let lossless = ResizeQuery {
+            webp_lossless: Some(true),
+            ..base
+        };
+
+        let (out_lossy, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossy, &config)
+                .expect("processing should succeed");
+        let (out_lossless, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossless, &config)
+                .expect("processing should succeed");
+
+        assert_ne!(
+            out_lossy.len(),
+            out_lossless.len(),
+            "lossy and lossless webp encodes of the same photographic source should differ in size"
         );
     }
 }

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -497,6 +497,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 
@@ -574,6 +577,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -468,6 +468,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
         let key = cache.generate_key(&params);


### PR DESCRIPTION
## Summary

JPEG always encoded at **75** and WebP at a hardcoded **82**. A resizing service exists to trade bytes against quality — not exposing that trade is why the imgproxy comparison could never compare output sizes at matched quality.

Closes #35, #4.

## A latent cache bug found while wiring it

`q:{0-100}` **already parsed** and already reached `ResizeQuery::quality` from the #53 URL rewrite. But no encoder ever read it — and it was never hashed into the cache key.

Verified against `main`: `quality` appears in `src/services/cache/handler.rs` only inside test literals, never within `generate_key`.

Harmless while the value was ignored. A **live cache-collision bug the moment quality reached an encoder** — which is precisely what this PR does. `CACHE_KEY_VERSION` 5 → 6.

## Added

- **`fq:{format}:{quality}`** — per-format override, imgproxy's `format_quality` grammar. `png` is **rejected with 400** rather than accepted and ignored: the crate's PNG path is a fixed lossless `CompressionType` with no continuous quality knob, and accepting an option that does nothing is the same silent-wrong-output class as #59.
- **`webpo:{compression}`** — lossless WebP. Deliberately a *partial* implementation of imgproxy's `webp_options`: the `webp` crate exposes only `encode`/`encode_lossless`, so extra arguments are rejected rather than silently dropped. `adr/0003` shows lossless genuinely wins on flat-colour content, so this is not hypothetical.

## Corrects a false premise in #35 — mine

#35 claims the crate supports progressive JPEG and chroma subsampling. **It does not.** Verified against `image` 0.25.10's vendored source: `JpegEncoder`'s entire public API is `new`, `new_with_quality`, `set_pixel_density`, `encode`, `encode_image`. No progressive encoding, 4:2:2 hardcoded with no way to configure it.

Either would need a different encoder (`mozjpeg`) — a C dependency, and not one to add unilaterally. Reported rather than half-done.

## Defaults

Unchanged, but now named rather than implicit: JPEG **75** (the crate's own default — what shipped before), WebP **82**. The latter was re-checked against `adr/0003`'s DSSIM-matched Kodak sweep, which asked for no change: 82 sits between the measured q80/q85 buckets, inside the flat 40–85 range where WebP is consistently 15–19% smaller than JPEG at equal quality.

## Verification

- `cargo check --features local_fs --bins --tests --benches` — 0 errors
- `cargo check --features s3` — 0 errors
- `cargo test --features local_fs` — **412 passed** (was 385)
- `cargo test --features s3` — **402 passed**

Tests cover monotonic size vs quality for both encoders, per-format override beating a lower global value, lossless WebP round-tripping byte-identical *and* differing from the lossy path (proving it is not a no-op), and out-of-range/unknown-format rejection at parse time.

## Reviewer focus

1. **The cache-key bump** — without it, quality changes would collide.
2. **Rejecting `fq:png`** — deliberate; confirm you would rather 400 than silently ignore.
3. **The partial `webpo` grammar** — rejects arguments imgproxy accepts. That is a compatibility gap, chosen over pretending to honour them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
