### PR TITLE
feat: apply EXIF orientation and forward ICC profiles (#33, #5)

### DIFF
--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -26,6 +26,7 @@ fn bench_cache_key(c: &mut Criterion) {
         webp_quality: None,
         webp_lossless: None,
         background: None,
+        autorotate: true,
     };
 
     c.bench_function("cache_key/generate_key", |b| {

--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -22,6 +22,9 @@ fn bench_cache_key(c: &mut Criterion) {
         grayscale: Some(false),
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     };
 

--- a/benches/fixtures.rs
+++ b/benches/fixtures.rs
@@ -192,6 +192,111 @@ pub fn photo_like_sized(width: u32, height: u32, format: ImageFormat) -> Vec<u8>
     })
 }
 
+pub const ORIENTED_W: u32 = 120;
+pub const ORIENTED_H: u32 = 80;
+/// Marker block side length, in canonical (already-upright) pixels - well
+/// inside both the marker and background regions, so sampling a few pixels
+/// in from any edge lands solidly in one colour even after JPEG's lossy
+/// compression and any resize filtering a test applies on top.
+const ORIENTED_MARKER: u32 = 20;
+
+/// Canonical (already-upright) marker image used to build the EXIF-
+/// orientation fixtures below (#33): a deliberately non-square `W`x`H`
+/// image (so a 90/270-degree rotation bug shows up as a dimension swap, not
+/// just a same-shape pixel mismatch) with a solid red marker block in its
+/// top-left corner and solid blue everywhere else - "upright" here means
+/// exactly this layout.
+pub fn oriented_canonical() -> RgbImage {
+    ImageBuffer::from_fn(ORIENTED_W, ORIENTED_H, |x, y| {
+        if x < ORIENTED_MARKER && y < ORIENTED_MARKER {
+            Rgb([220, 30, 30]) // marker: red
+        } else {
+            Rgb([30, 30, 220]) // background: blue
+        }
+    })
+}
+
+/// Builds a minimal, valid Exif TIFF blob - the `APP1` payload *minus* the
+/// leading `"Exif\0\0"` marker, which `JpegEncoder::set_exif_metadata`
+/// prepends itself (image-0.25.10 `src/codecs/jpeg/encoder.rs::write_exif`)
+/// and the decode-side `zune-jpeg` strips back off before handing the
+/// remainder to `Orientation::from_exif_chunk` (`zune-jpeg-0.5.15`
+/// `src/headers.rs::parse_app1`) - containing exactly one IFD0 entry: the
+/// Orientation tag (`0x0112`, TIFF type 3/SHORT, count 1) set to
+/// `exif_orientation` (the standard 1-8 EXIF orientation code). Byte layout
+/// mirrors exactly what `Orientation::from_exif_chunk`'s
+/// `locate_orientation_entry` helper (image-0.25.10 `src/metadata.rs`)
+/// parses: little-endian TIFF header, one directory entry, no next-IFD.
+fn minimal_exif_orientation(exif_orientation: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(26);
+    buf.extend_from_slice(b"II"); // little-endian byte order
+    buf.extend_from_slice(&42u16.to_le_bytes()); // TIFF magic
+    buf.extend_from_slice(&8u32.to_le_bytes()); // IFD0 offset (right after this 8-byte header)
+    buf.extend_from_slice(&1u16.to_le_bytes()); // 1 directory entry
+    buf.extend_from_slice(&0x0112u16.to_le_bytes()); // tag: Orientation
+    buf.extend_from_slice(&3u16.to_le_bytes()); // type: SHORT
+    buf.extend_from_slice(&1u32.to_le_bytes()); // count: 1
+    buf.extend_from_slice(&u16::from(exif_orientation).to_le_bytes()); // value (low 2 bytes of the 4-byte value field)
+    buf.extend_from_slice(&0u16.to_le_bytes()); // padding (high 2 bytes of the value field)
+    buf.extend_from_slice(&0u32.to_le_bytes()); // next IFD offset: none
+    buf
+}
+
+/// A JPEG fixture whose *stored* pixel data is the algebraic inverse of
+/// [`oriented_canonical`]'s transform for EXIF orientation `exif_orientation`
+/// (1-8), tagged with that orientation in its Exif `Orientation` field -
+/// exactly how a real camera's sensor output plus its orientation sensor
+/// reading works: the pixels are stored however the sensor happened to be
+/// held, and the tag says how to correct them for display.
+///
+/// Correctly decoding + autorotating this fixture must reproduce
+/// `oriented_canonical()` exactly, dimensions included (orientations 5-8
+/// swap width and height). The inverse per code is derived directly from
+/// `DynamicImage::apply_orientation`'s own match arms (image-0.25.10
+/// `src/images/dynimage.rs:1161-1179`):
+///
+/// | code | `apply_orientation` forward transform | inverse used to build `stored` |
+/// |------|----------------------------------------|-------------------------------|
+/// | 1    | identity                                | identity                      |
+/// | 2    | `fliph`                                 | `fliph` (self-inverse)        |
+/// | 3    | `rotate180`                             | `rotate180` (self-inverse)    |
+/// | 4    | `flipv`                                 | `flipv` (self-inverse)        |
+/// | 5    | `fliph(rotate90(x))`                    | `rotate270(fliph(x))`         |
+/// | 6    | `rotate90(x)`                           | `rotate270(x)`                |
+/// | 7    | `fliph(rotate270(x))`                   | `rotate90(fliph(x))`          |
+/// | 8    | `rotate270(x)`                          | `rotate90(x)`                 |
+///
+/// so this is a from-first-principles inverse of the exact production
+/// transform, not a round-trip through it.
+pub fn oriented(exif_orientation: u8) -> Vec<u8> {
+    cached(&format!("oriented_{exif_orientation}.jpg"), || {
+        let canonical = DynamicImage::ImageRgb8(oriented_canonical());
+        let stored = match exif_orientation {
+            1 => canonical,
+            2 => canonical.fliph(),
+            3 => canonical.rotate180(),
+            4 => canonical.flipv(),
+            5 => canonical.fliph().rotate270(),
+            6 => canonical.rotate270(),
+            7 => canonical.fliph().rotate90(),
+            8 => canonical.rotate90(),
+            other => panic!("unsupported EXIF orientation value {other} (expected 1-8)"),
+        };
+
+        use image::ImageEncoder;
+
+        let mut buf = Cursor::new(Vec::new());
+        let mut encoder = image::codecs::jpeg::JpegEncoder::new(&mut buf);
+        encoder
+            .set_exif_metadata(minimal_exif_orientation(exif_orientation))
+            .expect("JpegEncoder supports Exif metadata");
+        stored
+            .write_with_encoder(encoder)
+            .expect("fixture encoding should never fail");
+        buf.into_inner()
+    })
+}
+
 /// content-type for a fixture identified by name, as served by the
 /// `benchmark` bin's local origin server and used to pick a decode/encode
 /// extension in tests.

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -24,6 +24,9 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         grayscale: None,
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     }
 }

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -28,6 +28,7 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         webp_quality: None,
         webp_lossless: None,
         background: None,
+        autorotate: true,
     }
 }
 

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -179,6 +179,26 @@ pub struct ResizeQuery {
     /// (PNG/WebP), so invisible pixels compress instead of carrying whatever
     /// garbage RGB the source had under `alpha=0` (#60).
     pub background: Option<[u8; 3]>,
+
+    /// Whether to rotate/flip the decoded image according to its EXIF
+    /// `Orientation` tag before any resize happens (#33; imgproxy's
+    /// `auto_rotate`/`ar` processing option -
+    /// <https://docs.imgproxy.net/usage/processing#auto-rotate>).
+    ///
+    /// Defaults to `true` - unlike every other boolean option on this
+    /// struct (`enlarge`, `grayscale`), matching imgproxy's own documented
+    /// default (`IMGPROXY_AUTO_ROTATE: true`): a phone photo's pixels are
+    /// stored sideways/upside-down as a matter of course, so leaving them
+    /// that way unless a caller opts in would produce the wrong output for
+    /// the common case, not just an unusual one.
+    ///
+    /// `ImageService::process_image_blocking_with_limits`
+    /// (`src/services/image/handler.rs`) applies this via
+    /// `DynamicImage::apply_orientation` immediately after decode and
+    /// before any resize/crop math - order matters, since a `Rotate90`/
+    /// `Rotate270` orientation swaps width and height, and applying it
+    /// after a crop would compose the crop against the wrong axes.
+    pub autorotate: bool,
 }
 
 /// Path parameter for the (unsigned, key-validated) download route

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -137,10 +137,35 @@ pub struct ResizeQuery {
     pub enlarge: bool,
 
     /// Output encode quality (imgproxy's `q:{0-100}` processing option).
-    /// `None` lets the encoder pick its own default. Threaded through for
-    /// the concurrently-landing lossy-WebP encoding work
-    /// (`src/services/image/handler.rs`, owned by another agent).
+    /// `None` lets the encoder pick its own default
+    /// (`ImageService::DEFAULT_JPEG_QUALITY` / `DEFAULT_WEBP_QUALITY`,
+    /// `src/services/image/handler.rs`). Overridden per-format by
+    /// `jpeg_quality`/`webp_quality` below when those are set (#35) -
+    /// mirrors imgproxy's own `q` (global) vs `format_quality` (per-format)
+    /// precedence (<https://docs.imgproxy.net/usage/processing#quality>).
     pub quality: Option<u8>,
+
+    /// Per-format quality override (imgproxy's `format_quality`/`fq:{format}:
+    /// {quality}:...` processing option, #35). Takes precedence over
+    /// `quality` for JPEG output when set - see
+    /// `ImageService::process_image_blocking_with_limits`
+    /// (`src/services/image/handler.rs`) for the exact precedence.
+    pub jpeg_quality: Option<u8>,
+
+    /// Per-format quality override for WebP output - see `jpeg_quality`
+    /// above for the general shape; same precedence over `quality`.
+    pub webp_quality: Option<u8>,
+
+    /// Encode WebP losslessly instead of lossily (imgproxy's `webp_options`/
+    /// `webpo:{compression}` processing option, #35 - only the `compression`
+    /// slot is implemented, see [`crate::modules::url::options`] for why).
+    /// `None`/`Some(false)` keeps the existing lossy path
+    /// (`ImageService::encode_webp`'s `lossless` parameter); `Some(true)`
+    /// encodes losslessly and ignores `quality`/`webp_quality` entirely,
+    /// matching `encode_webp`'s own "quality is used only when lossless is
+    /// false" contract. Meaningless (silently ignored) for non-WebP output,
+    /// same as every other format-specific option in this struct.
+    pub webp_lossless: Option<bool>,
 
     /// Background colour, as an `[R, G, B]` triple (imgproxy's
     /// `background`/`bg:{R}:{G}:{B}` or `bg:{hex}` processing option, #34).

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -271,6 +271,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -275,6 +275,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -118,6 +118,7 @@ impl ParsedRequest {
             webp_quality: self.options.webp_quality,
             webp_lossless: self.options.webp_lossless,
             background: self.options.background,
+            autorotate: self.options.autorotate.unwrap_or(true),
         }
     }
 }
@@ -155,8 +156,10 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
+        // Exercises every option the grammar accepts in one path, so a new
+        // option that silently fails to round-trip shows up here.
         let path = format!(
-            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp"
+            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/ar:0/{encoded}.webp"
         );
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
@@ -175,6 +178,7 @@ mod tests {
         assert!(query.enlarge);
         assert_eq!(query.format, ImageFormat::Webp);
         assert_eq!(query.background, Some([255, 0, 0]));
+        assert!(!query.autorotate, "ar:0 in the URL must disable autorotate");
     }
 
     #[test]
@@ -198,6 +202,10 @@ mod tests {
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);
         assert_eq!(query.background, None);
+        assert!(
+            query.autorotate,
+            "autorotate must default to true when no `ar` segment is present"
+        );
     }
 
     #[test]

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -114,6 +114,9 @@ impl ParsedRequest {
             grayscale: self.options.grayscale,
             enlarge: self.options.enlarge.unwrap_or(false),
             quality: self.options.quality,
+            jpeg_quality: self.options.jpeg_quality,
+            webp_quality: self.options.webp_quality,
+            webp_lossless: self.options.webp_lossless,
             background: self.options.background,
         }
     }
@@ -152,8 +155,9 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
-        let path =
-            format!("/SIG/rs:fill:300:300/q:80/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp");
+        let path = format!(
+            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp"
+        );
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
         let query = parsed.into_resize_query();
@@ -163,6 +167,9 @@ mod tests {
         assert_eq!(query.height, Some(300));
         assert_eq!(query.resize_type, crate::models::params::ResizeType::Fill);
         assert_eq!(query.quality, Some(80));
+        assert_eq!(query.webp_quality, Some(90));
+        assert_eq!(query.webp_lossless, Some(true));
+        assert_eq!(query.jpeg_quality, None);
         assert_eq!(query.blur_sigma, Some(5.0));
         assert_eq!(query.grayscale, Some(true));
         assert!(query.enlarge);
@@ -184,6 +191,9 @@ mod tests {
             crate::models::params::ResizeType::default()
         );
         assert_eq!(query.quality, None);
+        assert_eq!(query.jpeg_quality, None);
+        assert_eq!(query.webp_quality, None);
+        assert_eq!(query.webp_lossless, None);
         assert_eq!(query.blur_sigma, None);
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -6,8 +6,9 @@ use crate::models::params::ResizeType;
 /// own short option codes (`rs`, `q`, `bl`, `g`, `el`) so a client library
 /// written for imgproxy's URL format produces something this parser accepts
 /// for the capability set #53 keeps: width, height, resize type, blur,
-/// grayscale, enlarge, quality (format comes from the trailing
-/// `.{extension}` instead - see [`super::source`]).
+/// grayscale, enlarge, quality, per-format quality override, webp lossless
+/// (format comes from the trailing `.{extension}` instead - see
+/// [`super::source`]).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ProcessingOptions {
     pub width: Option<u32>,
@@ -21,6 +22,15 @@ pub struct ProcessingOptions {
     pub grayscale: Option<bool>,
     pub enlarge: Option<bool>,
     pub quality: Option<u8>,
+    /// `fq`'s parsed `jpg`/`jpeg` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::jpeg_quality`].
+    pub jpeg_quality: Option<u8>,
+    /// `fq`'s parsed `webp` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_quality`].
+    pub webp_quality: Option<u8>,
+    /// `webpo`'s parsed `compression` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_lossless`].
+    pub webp_lossless: Option<bool>,
     /// `bg`'s parsed `[R, G, B]` triple (#34) - see
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
@@ -66,6 +76,81 @@ impl ProcessingOptions {
                 "q" => {
                     let [value] = require_args::<1>(&args, segment)?;
                     opts.quality = Some(parse_bounded(value, segment, 0, 100)?);
+                }
+                // fq:{format1}:{quality1}:{format2}:{quality2}:... - imgproxy's
+                // `format_quality`/`fq` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#format-quality>):
+                // "adds or redefines format_quality values" for the current
+                // request, on top of `q`'s global default. Only `jpg`/`jpeg`
+                // and `webp` are accepted - PNG output always uses this
+                // crate's fixed `CompressionType::Best` (no continuous 0-100
+                // quality knob exists to override), so `fq:png:N` is rejected
+                // with 400 rather than silently ignored. Repeating a format
+                // (`fq:jpg:80:jpg:90`) lets the later pair win, same as
+                // imgproxy's own "redefines" wording implies.
+                "fq" => {
+                    if args.is_empty() || !args.len().is_multiple_of(2) {
+                        return Err(UrlParseError::InvalidOptionValue {
+                            option: segment.to_string(),
+                            reason: "expected one or more format:quality pairs".to_string(),
+                        });
+                    }
+                    for pair in args.chunks(2) {
+                        let (format, value) = (pair[0], pair[1]);
+                        let quality = parse_bounded(value, segment, 0, 100)?;
+                        match format {
+                            "jpg" | "jpeg" => opts.jpeg_quality = Some(quality),
+                            "webp" => opts.webp_quality = Some(quality),
+                            "png" => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: "png has no adjustable quality in this encoder \
+                                             (PNG output always uses fixed CompressionType::Best)"
+                                        .to_string(),
+                                });
+                            }
+                            other => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: format!(
+                                        "unsupported format {other:?} for format_quality \
+                                         (expected jpg, jpeg or webp)"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                // webpo:{compression} - a deliberately partial implementation
+                // of imgproxy's `webp_options`/`webpo:{compression}:
+                // {smart_subsample}:{preset}` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#webp-options>).
+                // Only the `compression` slot is implemented - the `webp`
+                // crate (0.3.1) this project depends on exposes exactly two
+                // encode modes, `Encoder::encode` (lossy) and
+                // `Encoder::encode_lossless`, with no `smart_subsample` or
+                // `preset` knob at all, and no `mixed` mode either. Requiring
+                // exactly one argument (rather than silently accepting and
+                // ignoring imgproxy's other two slots) is deliberate: a
+                // caller who actually needs `smart_subsample`/`preset` gets a
+                // clear 400 here instead of a silently-ignored parameter.
+                "webpo" => {
+                    let [compression] = require_args::<1>(&args, segment)?;
+                    opts.webp_lossless = Some(match compression {
+                        "lossy" => false,
+                        "lossless" => true,
+                        other => {
+                            return Err(UrlParseError::InvalidOptionValue {
+                                option: segment.to_string(),
+                                reason: format!(
+                                    "{other:?} is not a supported webp compression mode \
+                                     (expected lossy or lossless - this encoder has no \
+                                     mixed mode, and does not support imgproxy's \
+                                     smart_subsample/preset slots)"
+                                ),
+                            });
+                        }
+                    });
                 }
                 "bl" => {
                     let [value] = require_args::<1>(&args, segment)?;
@@ -285,6 +370,81 @@ mod tests {
     }
 
     #[test]
+    fn parses_format_quality_for_jpeg_and_webp() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:webp:90"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+    }
+
+    #[test]
+    fn format_quality_accepts_jpeg_alias() {
+        let opts = ProcessingOptions::parse(&["fq:jpeg:70"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(70));
+    }
+
+    #[test]
+    fn format_quality_later_pair_overrides_earlier_for_same_format() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:jpg:40"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(40));
+    }
+
+    #[test]
+    fn format_quality_rejects_png() {
+        assert!(ProcessingOptions::parse(&["fq:png:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_unknown_format() {
+        assert!(ProcessingOptions::parse(&["fq:avif:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_odd_argument_count() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:80:webp"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_out_of_range_value() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:101"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_empty_args() {
+        assert!(ProcessingOptions::parse(&["fq"]).is_err());
+    }
+
+    #[test]
+    fn parses_webp_lossless() {
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossless"])
+                .unwrap()
+                .webp_lossless,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossy"])
+                .unwrap()
+                .webp_lossless,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn webp_lossless_rejects_unsupported_mode() {
+        assert!(ProcessingOptions::parse(&["webpo:mixed"]).is_err());
+        assert!(ProcessingOptions::parse(&["webpo:nope"]).is_err());
+    }
+
+    #[test]
+    fn webp_lossless_rejects_extra_arguments() {
+        // imgproxy's own 3-slot grammar (compression:smart_subsample:preset)
+        // - this crate only implements the first slot, and rejects rather
+        // than silently ignoring the other two (see the `webpo` match arm's
+        // doc comment).
+        assert!(ProcessingOptions::parse(&["webpo:lossless::4"]).is_err());
+    }
+
+    #[test]
     fn parses_blur() {
         let opts = ProcessingOptions::parse(&["bl:5"]).unwrap();
         assert_eq!(opts.blur_sigma, Some(5.0));
@@ -327,6 +487,8 @@ mod tests {
         let opts = ProcessingOptions::parse(&[
             "rs:fill:300:300",
             "q:80",
+            "fq:webp:90",
+            "webpo:lossless",
             "bl:5",
             "g:true",
             "el:1",
@@ -337,6 +499,8 @@ mod tests {
         assert_eq!(opts.height, Some(300));
         assert_eq!(opts.resize_type, ResizeType::Fill);
         assert_eq!(opts.quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+        assert_eq!(opts.webp_lossless, Some(true));
         assert_eq!(opts.blur_sigma, Some(5.0));
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -35,6 +35,12 @@ pub struct ProcessingOptions {
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
     pub background: Option<[u8; 3]>,
+    /// `ar`'s parsed boolean (#33) - see
+    /// [`crate::models::params::ResizeQuery::autorotate`]. `None` means
+    /// "use the default", which is `true` (autorotate stays on) unlike
+    /// every other `Option<bool>` field here - see `ResizeQuery::autorotate`'s
+    /// own doc comment for why.
+    pub autorotate: Option<bool>,
 }
 
 /// A processing-option path segment always contains a `:` (`rs:fill:300:300`,
@@ -169,6 +175,17 @@ impl ProcessingOptions {
                 // argument shapes.
                 "bg" => {
                     opts.background = Some(parse_background(&args, segment)?);
+                }
+                // ar:{0|1|true|false} - imgproxy's `auto_rotate`/`ar`
+                // processing option (#33,
+                // <https://docs.imgproxy.net/usage/processing#auto-rotate>):
+                // rotates/flips the decoded image per its EXIF orientation
+                // tag before any resize happens. Carried through to
+                // `ResizeQuery::autorotate`, defaulting to `true` when this
+                // segment is absent (see that field's doc comment).
+                "ar" => {
+                    let [value] = require_args::<1>(&args, segment)?;
+                    opts.autorotate = Some(parse_bool(value, segment)?);
                 }
                 other => return Err(UrlParseError::UnknownOption(other.to_string())),
             }
@@ -483,6 +500,32 @@ mod tests {
     }
 
     #[test]
+    fn parses_autorotate() {
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:1"]).unwrap().autorotate,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:0"]).unwrap().autorotate,
+            Some(false)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:true"]).unwrap().autorotate,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:false"]).unwrap().autorotate,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn autorotate_defaults_to_none_when_absent() {
+        let opts = ProcessingOptions::parse(&[]).unwrap();
+        assert_eq!(opts.autorotate, None);
+    }
+
+    #[test]
     fn combines_multiple_options() {
         let opts = ProcessingOptions::parse(&[
             "rs:fill:300:300",
@@ -493,6 +536,7 @@ mod tests {
             "g:true",
             "el:1",
             "bg:255:0:0",
+            "ar:0",
         ])
         .unwrap();
         assert_eq!(opts.width, Some(300));
@@ -505,6 +549,7 @@ mod tests {
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));
         assert_eq!(opts.background, Some([255, 0, 0]));
+        assert_eq!(opts.autorotate, Some(false));
     }
 
     #[test]

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -30,8 +30,17 @@ use sha2::{Digest, Sha256};
 /// bytes. Now that it changes what gets encoded - both the flatten colour
 /// for alpha->no-alpha conversions and the fill colour for fully-transparent
 /// pixels when alpha is kept - two requests differing only in `background`
-/// must not collide onto a v4 key that never hashed it.
-const CACHE_KEY_VERSION: u8 = 5;
+/// must not collide onto a v4 key that never hashed it. v6 adds `quality`,
+/// `jpeg_quality`, `webp_quality` and `webp_lossless` (#35): `quality` was
+/// already parsed into `ResizeQuery` (from the URL grammar's `q:{0-100}`)
+/// before this change, but was never fed into `generate_key` at all - a
+/// pure oversight, not a deliberate "doesn't affect output" omission like
+/// `resize_type` was pre-#59, since quality has always affected encoded
+/// bytes for whatever encoder actually used it. Now that the encoders in
+/// `src/services/image/handler.rs` honour these fields, two requests
+/// differing only in quality/format-quality/losslessness must not collide
+/// onto a v5 key that never hashed any of them.
+const CACHE_KEY_VERSION: u8 = 6;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -104,6 +113,29 @@ impl CacheService {
         // Always-present (not `Option<bool>`, so no "None" bucket needed
         // here unlike `grayscale`/`blur_sigma`).
         Self::update_field(&mut hasher, params.enlarge.to_string().as_bytes());
+
+        // `quality`/`jpeg_quality`/`webp_quality`/`webp_lossless` (#35, v6)
+        // change the encoder's output bytes directly - see the v6
+        // `CACHE_KEY_VERSION` note above for why these were missing before.
+        match params.quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.jpeg_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_lossless {
+            Some(lossless) => Self::update_field(&mut hasher, lossless.to_string().as_bytes()),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
 
         // `background` (#34/#60, v5) changes the resize pipeline's output
         // bytes wherever alpha is flattened or transparent pixels are
@@ -192,6 +224,9 @@ mod tests {
             grayscale,
             enlarge,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -359,6 +394,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         };
 
@@ -371,6 +409,120 @@ mod tests {
             keys.len(),
             4,
             "each distinct background (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): `quality` changes the encoded output bytes, so
+    /// distinct qualities - and the unset ("use the encoder's default")
+    /// case - must not collide onto the same cache key.
+    #[test]
+    fn quality_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(30), Some(75), Some(90)]
+            .into_iter()
+            .map(|q| cache.generate_key(&base(q)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            4,
+            "each distinct quality (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): a per-format quality override changes the encoded
+    /// output bytes independently of the global `quality`, so it must be
+    /// its own dimension in the cache key rather than being folded into (or
+    /// ignored relative to) `quality`.
+    #[test]
+    fn format_quality_produces_distinct_keys_from_global_quality() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>, jpeg_quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let global_only = cache.generate_key(&base(Some(80), None));
+        let override_only = cache.generate_key(&base(None, Some(80)));
+        let both = cache.generate_key(&base(Some(80), Some(80)));
+        let neither = cache.generate_key(&base(None, None));
+
+        let keys: HashSet<String> = [
+            global_only.clone(),
+            override_only.clone(),
+            both.clone(),
+            neither.clone(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            keys.len(),
+            4,
+            "quality and jpeg_quality must each be an independent cache-key dimension"
+        );
+    }
+
+    /// #35 (v6 bump): `webp_lossless` changes the encoded output bytes
+    /// (an entirely different codec path - `encode_lossless` vs `encode`),
+    /// so it must not collide with the lossy default.
+    #[test]
+    fn webp_lossless_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |webp_lossless: Option<bool>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Webp,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(false), Some(true)]
+            .into_iter()
+            .map(|l| cache.generate_key(&base(l)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct webp_lossless value (including unset) must produce a distinct cache key"
         );
     }
 
@@ -396,6 +548,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
 

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -30,7 +30,7 @@ use sha2::{Digest, Sha256};
 /// bytes. Now that it changes what gets encoded - both the flatten colour
 /// for alpha->no-alpha conversions and the fill colour for fully-transparent
 /// pixels when alpha is kept - two requests differing only in `background`
-/// must not collide onto a v4 key that never hashed it. v6 adds `quality`,
+/// must not collide onto a v4 key that never hashed it. v7 adds `quality`,
 /// `jpeg_quality`, `webp_quality` and `webp_lossless` (#35): `quality` was
 /// already parsed into `ResizeQuery` (from the URL grammar's `q:{0-100}`)
 /// before this change, but was never fed into `generate_key` at all - a
@@ -40,7 +40,16 @@ use sha2::{Digest, Sha256};
 /// `src/services/image/handler.rs` honour these fields, two requests
 /// differing only in quality/format-quality/losslessness must not collide
 /// onto a v5 key that never hashed any of them.
-const CACHE_KEY_VERSION: u8 = 6;
+///
+/// v7 also adds
+/// `autorotate` (#33): before this, EXIF orientation was parsed but never
+/// applied, so every request produced un-rotated output regardless of
+/// `autorotate` and the field had no effect on output bytes. Now that a
+/// non-identity source orientation changes the output whenever autorotate
+/// is on, two requests differing only in `autorotate` - or any request
+/// against a since-fixed cache entry produced before this change existed at
+/// all - must not collide onto a v5 key that never hashed it.
+const CACHE_KEY_VERSION: u8 = 7;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -147,6 +156,13 @@ impl CacheService {
             None => Self::update_field(&mut hasher, b"None"),
         }
 
+        // `autorotate` (#33, v6) changes the resize pipeline's output
+        // whenever the source carries a non-identity EXIF orientation, so
+        // it must be part of the key like every other output-affecting
+        // field - see the v6 `CACHE_KEY_VERSION` note above. Always-present
+        // (not `Option<bool>`), so no "None" bucket is needed here.
+        Self::update_field(&mut hasher, params.autorotate.to_string().as_bytes());
+
         let result = hasher.finalize();
         format!("{:}{:x}.{}", self.minio_sub_path, result, params.format)
     }
@@ -228,6 +244,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 
@@ -376,6 +393,37 @@ mod tests {
         );
     }
 
+    /// #33 (v6 bump): `autorotate` changes the resize pipeline's output
+    /// whenever the source has a non-identity EXIF orientation, so two
+    /// requests differing only in `autorotate` must not collide onto the
+    /// same cache key.
+    #[test]
+    fn autorotate_true_and_false_produce_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |autorotate: bool| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+            autorotate,
+        };
+
+        assert_ne!(
+            cache.generate_key(&base(true)),
+            cache.generate_key(&base(false))
+        );
+    }
+
     /// #34/#60 (v5 bump): `background` changes the resize pipeline's output
     /// bytes (flatten/normalise colour), so distinct backgrounds - and the
     /// unset ("use the default") case - must not collide onto the same
@@ -398,6 +446,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some([255, 255, 255]), Some([0, 0, 0]), Some([1, 2, 3])]
@@ -433,6 +482,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some(30), Some(75), Some(90)]
@@ -469,6 +519,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let global_only = cache.generate_key(&base(Some(80), None));
@@ -512,6 +563,7 @@ mod tests {
             webp_quality: None,
             webp_lossless,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some(false), Some(true)]
@@ -552,6 +604,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -16,19 +16,31 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use url::Url;
 
-/// Placeholder lossy-WebP encode quality (0.0-100.0, libwebp's own scale).
-/// `ResizeQuery` (`src/models/params.rs`) now carries a real `quality:
-/// Option<u8>` field, parsed from the signed URL grammar's `q:{0-100}`
-/// processing option (#53/#27) - wiring it into the call site below instead
-/// of this placeholder is a one-line change (`ImageService::encode_webp`
-/// already accepts `quality`/`lossless` as plain parameters), just not made
-/// here since it's this file's own call to make. 82.0 is a commonly-cited
-/// "high quality, still meaningfully smaller than lossless" WebP setting.
+/// Default lossy-WebP encode quality (0.0-100.0, libwebp's own scale), used
+/// when neither `ResizeQuery::webp_quality` nor `ResizeQuery::quality` is
+/// set (#35). 82.0 is a commonly-cited "high quality, still meaningfully
+/// smaller than lossless" WebP setting, and is corroborated by
+/// `adr/0003-webp-measurement.md`'s matched-DSSIM sweep against the Kodak
+/// corpus: 82 falls between the measured q80 bucket (median WebP/JPEG size
+/// ratio 0.8497, n=23 images) and q85 bucket (0.8596, n=18), both inside the
+/// flat, no-crossover 40-85 range where WebP is consistently 15-19% smaller
+/// than JPEG at equal perceptual quality. That ADR explicitly re-checked
+/// this constant and requested no change.
 ///
 /// `pub` (like `encode_webp` itself) so `benches/encode.rs` can benchmark
 /// the exact default production uses instead of a hardcoded duplicate that
 /// could silently drift from it.
 pub const DEFAULT_WEBP_QUALITY: f32 = 82.0;
+
+/// Default JPEG encode quality (1-100, the `image` crate's own scale), used
+/// when neither `ResizeQuery::jpeg_quality` nor `ResizeQuery::quality` is
+/// set (#35). Matches `image::codecs::jpeg::JpegEncoder::new`'s own default
+/// (`image-0.25.10/src/codecs/jpeg/encoder.rs:392`, `new_with_quality(w,
+/// 75)`) - this crate's JPEG output already encoded at 75 before #35 (via
+/// `DynamicImage::write_to`'s default encoder construction), just without a
+/// named constant or a way to override it per-request. `adr/0003` measured
+/// against this exact default and requested no change to it either.
+pub const DEFAULT_JPEG_QUALITY: u8 = 75;
 
 /// Default background colour (#34) used both to flatten alpha before
 /// encoding to a format with no alpha channel, and as the fill colour for
@@ -571,11 +583,33 @@ impl ImageService {
         // for #60 that doesn't touch `Cargo.toml`: `PngEncoder` and its
         // `CompressionType`/`FilterType` enums are already part of the
         // `image` crate's own public API under the `png` feature this crate
-        // already depends on, not a new dependency. JPEG is unaffected and
-        // keeps going through `write_to` exactly as before.
+        // already depends on, not a new dependency. JPEG now uses an
+        // explicit `JpegEncoder::new_with_quality` (#35) instead of
+        // `write_to`'s implicit default-quality construction, so
+        // `params.quality`/`params.jpeg_quality` actually reach the encoder.
+        //
+        // PNG has no quality knob in `params` to honour - `CompressionType`
+        // is a fixed lossless setting, not a continuous 0-100 scale, and
+        // `fq:png:N` is rejected at parse time
+        // (`src/modules/url/options.rs`) rather than silently accepted and
+        // ignored here.
         let output_bytes = match output_format {
-            ImageFormat::WebP => Self::encode_webp(&img, DEFAULT_WEBP_QUALITY, false)
-                .context(format!("Failed to encode image to {:?}", output_format))?,
+            ImageFormat::WebP => {
+                let lossless = params.webp_lossless.unwrap_or(false);
+                // `quality` is meaningless (and unused by `encode_webp`)
+                // when `lossless` is set - see that function's own doc
+                // comment - but still resolved unconditionally here since
+                // that's simpler than threading an `Option` through just to
+                // skip computing a value nothing will read.
+                let quality = params
+                    .webp_quality
+                    .or(params.quality)
+                    .map(f32::from)
+                    .unwrap_or(DEFAULT_WEBP_QUALITY);
+
+                Self::encode_webp(&img, quality, lossless)
+                    .context(format!("Failed to encode image to {:?}", output_format))?
+            }
             ImageFormat::Png => {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
@@ -590,18 +624,28 @@ impl ImageService {
 
                 buf.into_inner()
             }
-            _ => {
-                // Pre-allocate buffer based on estimated size - only
-                // meaningful for the `write_to` path below; the WebP path
-                // above gets its output buffer from libwebp itself.
+            ImageFormat::Jpeg => {
+                let quality = params
+                    .jpeg_quality
+                    .or(params.quality)
+                    .unwrap_or(DEFAULT_JPEG_QUALITY);
+
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                img.write_to(&mut buf, output_format)
+                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
                 buf.into_inner()
             }
+            // `output_format` is only ever constructed from `params.format`
+            // (`crate::models::params::ImageFormat`, three variants: `Jpg`,
+            // `Png`, `Webp`) a few lines above, so every value the `match`
+            // above doesn't already handle is unreachable in practice - kept
+            // as a hard error rather than a silent generic `write_to` fallback
+            // so a future fourth format doesn't quietly skip quality handling.
+            other => anyhow::bail!("unsupported output format {other:?}"),
         };
 
         Ok((output_bytes, content_type.to_string()))
@@ -1055,6 +1099,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -1972,6 +2019,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         }
     }
@@ -2157,6 +2207,177 @@ mod tests {
             output.len() < 3_000,
             "expected flat-colour PNG under 3,000 bytes with Best compression, got {}",
             output.len()
+        );
+    }
+
+    // ---- #35: quality wiring (JpegEncoder::new_with_quality, encode_webp's
+    // quality/lossless parameters, per-format override, cache-key coverage
+    // for these tested separately in `src/services/cache/handler.rs`) ----
+
+    /// A lower JPEG quality must always produce a smaller (or equal, but in
+    /// practice smaller for a real photographic fixture) output than a
+    /// higher one, for the same source and dimensions - the whole point of
+    /// exposing the knob at all.
+    #[test]
+    fn jpeg_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Jpg,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// Same monotonicity property as `jpeg_quality_changes_output_size_monotonically`,
+    /// but through the lossy-WebP path (`Self::encode_webp`'s `quality`
+    /// parameter) instead of JPEG's.
+    #[test]
+    fn webp_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Webp,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// `jpeg_quality` (the `fq:jpg:{quality}` per-format override) must win
+    /// over the lower global `quality` - imgproxy's own documented
+    /// precedence for `format_quality` over `quality`.
+    #[test]
+    fn format_quality_override_beats_global_quality() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let global_low = ResizeQuery {
+            quality: Some(30),
+            ..base.clone()
+        };
+        let override_high = ResizeQuery {
+            quality: Some(30),
+            jpeg_quality: Some(90),
+            ..base
+        };
+
+        let (out_global, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &global_low, &config)
+                .expect("processing should succeed");
+        let (out_override, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &override_high, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            out_override.len() > out_global.len(),
+            "expected jpeg_quality=90 ({} bytes) to override the lower global quality=30 \
+             ({} bytes), producing larger output",
+            out_override.len(),
+            out_global.len()
+        );
+    }
+
+    /// Lossless WebP (`webp_lossless: Some(true)`) must round-trip the
+    /// source pixels exactly - no resize/blur/grayscale filter applied, and
+    /// a source with no alpha channel so the #34/#60 flatten/normalise
+    /// stage is a no-op, isolating this to purely the encoder's own
+    /// lossless-ness.
+    #[test]
+    fn webp_lossless_round_trips_byte_identical_pixels() {
+        let bytes = fixtures::photo_like(); // 1920x1080, no alpha channel
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            webp_lossless: Some(true),
+            ..query(None, None)
+        };
+
+        let (output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let original = image::load_from_memory(&bytes)
+            .expect("source should decode")
+            .to_rgba8();
+        let decoded = image::load_from_memory(&output)
+            .expect("lossless webp output should decode")
+            .to_rgba8();
+
+        assert_eq!(decoded.dimensions(), original.dimensions());
+        assert_eq!(
+            decoded.as_raw(),
+            original.as_raw(),
+            "lossless webp round-trip must be byte-identical to the source pixels"
+        );
+    }
+
+    /// Lossless WebP must actually take the `encode_lossless` path, not
+    /// merely happen to look identical - `lossless: Some(false)` (still
+    /// lossy) on the exact same source/dimensions must produce different
+    /// (and, for a real photographic fixture, larger) output, proving the
+    /// flag is wired through rather than a no-op that always round-trips
+    /// because e.g. quality was already 100.
+    #[test]
+    fn webp_lossless_differs_from_lossy_output() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            ..query(Some(400), Some(300))
+        };
+
+        let lossy = ResizeQuery {
+            webp_lossless: Some(false),
+            ..base.clone()
+        };
+        let lossless = ResizeQuery {
+            webp_lossless: Some(true),
+            ..base
+        };
+
+        let (out_lossy, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossy, &config)
+                .expect("processing should succeed");
+        let (out_lossless, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossless, &config)
+                .expect("processing should succeed");
+
+        assert_ne!(
+            out_lossy.len(),
+            out_lossless.len(),
+            "lossy and lossless webp encodes of the same photographic source should differ in size"
         );
     }
 }

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -7,7 +7,8 @@ use derive_builder::Builder;
 use fast_image_resize as fir;
 use futures::StreamExt;
 use image::imageops::FilterType;
-use image::{DynamicImage, GenericImageView, ImageFormat};
+use image::metadata::Orientation;
+use image::{DynamicImage, GenericImageView, ImageDecoder, ImageEncoder, ImageFormat};
 use reqwest::redirect::Policy;
 use reqwest::{Client, Response};
 use std::io::Cursor;
@@ -423,7 +424,20 @@ impl ImageService {
         let (src_width, src_height) = Self::peek_dimensions(image_bytes, format)?;
         Self::check_source_resolution(src_width, src_height, config.max_src_resolution_mp)?;
 
-        let img = Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp)?;
+        let (mut img, orientation, icc_profile) =
+            Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp)?;
+
+        // #33: autorotate (imgproxy's `auto_rotate`/`ar` option, on by
+        // default - see `ResizeQuery::autorotate`) must be applied *before*
+        // any resize/crop math below, not after: `Orientation::Rotate90`/
+        // `Rotate270` swap width and height, so `src_width`/`src_height`
+        // (read immediately below, and used for every fit/fill/force/auto
+        // decision and the #36 upscale guard) must already reflect the
+        // corrected axes. Applying it after a crop would compose the crop
+        // against the wrong axes entirely.
+        if params.autorotate {
+            img.apply_orientation(orientation);
+        }
 
         let (src_width, src_height) = img.dimensions();
 
@@ -586,13 +600,30 @@ impl ImageService {
         // already depends on, not a new dependency. JPEG now uses an
         // explicit `JpegEncoder::new_with_quality` (#35) instead of
         // `write_to`'s implicit default-quality construction, so
-        // `params.quality`/`params.jpeg_quality` actually reach the encoder.
+        // `params.quality`/`params.jpeg_quality` actually reach the encoder
+        // - and, being an explicit `JpegEncoder` rather than whatever
+        // `write_to` builds internally, it's also the only way to reach
+        // `ImageEncoder::set_icc_profile` (#33), so the same encoder value
+        // now carries both the requested quality and the forwarded colour
+        // profile.
         //
         // PNG has no quality knob in `params` to honour - `CompressionType`
         // is a fixed lossless setting, not a continuous 0-100 scale, and
         // `fq:png:N` is rejected at parse time
         // (`src/modules/url/options.rs`) rather than silently accepted and
         // ignored here.
+        //
+        // #33: `icc_profile`, if the source carried one, is forwarded to
+        // whichever of these two encoders is used - both support embedding
+        // it (`image-0.25.10/src/codecs/{png,jpeg/encoder}.rs`). WebP is
+        // the one format this can't cover: the `webp` crate (0.3.1, this
+        // service's only route to *lossy* WebP encoding - see the doc
+        // comment above) has no ICC-profile API at all, so a source colour
+        // profile is still dropped on that path. Fixing that would mean
+        // either switching WebP encoding to a crate with profile support or
+        // patching raw ICC chunks into libwebp's container format by hand -
+        // real work, not a small addition, so it's left as follow-up rather
+        // than half-done here.
         let output_bytes = match output_format {
             ImageFormat::WebP => {
                 let lossless = params.webp_lossless.unwrap_or(false);
@@ -614,11 +645,19 @@ impl ImageService {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                let encoder = image::codecs::png::PngEncoder::new_with_quality(
+                let mut encoder = image::codecs::png::PngEncoder::new_with_quality(
                     &mut buf,
                     image::codecs::png::CompressionType::Best,
                     image::codecs::png::FilterType::Adaptive,
                 );
+                if let Some(icc) = icc_profile {
+                    // `PngEncoder::set_icc_profile` only fails for
+                    // genuinely unsupported encoders, never for
+                    // `PngEncoder` itself - ignore failure rather than turn
+                    // a best-effort colour-fidelity improvement into a hard
+                    // request error.
+                    let _ = encoder.set_icc_profile(icc);
+                }
                 img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
@@ -633,7 +672,15 @@ impl ImageService {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                let mut encoder =
+                    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                if let Some(icc) = icc_profile {
+                    // Same best-effort reasoning as the PNG branch above:
+                    // `JpegEncoder::set_icc_profile` only fails for
+                    // genuinely unsupported encoders, never for
+                    // `JpegEncoder` itself.
+                    let _ = encoder.set_icc_profile(icc);
+                }
                 img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
@@ -987,14 +1034,49 @@ impl ImageService {
     /// accidental 512MiB `max_alloc` default (#26). This is defense in
     /// depth behind `check_source_resolution`'s header-only check, not a
     /// replacement for it.
+    ///
+    /// Also returns the source's EXIF `Orientation` (#33) and embedded ICC
+    /// colour profile, if any - both must be read off the `ImageDecoder`
+    /// before it's consumed by `DynamicImage::from_decoder`, which is why
+    /// this goes through `ImageReader::into_decoder` rather than the
+    /// simpler `ImageReader::decode` it used to call directly.
+    /// `orientation` defaults to `Orientation::NoTransforms` (rather than
+    /// failing the whole request) if it can't be read - a source with
+    /// malformed EXIF should still decode and process, just without
+    /// autorotation.
     fn decode_with_limits(
         image_bytes: &[u8],
         format: Option<ImageFormat>,
         max_src_resolution_mp: u64,
-    ) -> Result<image::DynamicImage> {
+    ) -> Result<(image::DynamicImage, Orientation, Option<Vec<u8>>)> {
         let mut reader = Self::make_reader(image_bytes, format)?;
-        reader.limits(Self::build_decode_limits(max_src_resolution_mp));
-        reader.decode().context("Failed to decode image")
+        let limits = Self::build_decode_limits(max_src_resolution_mp);
+        reader.limits(limits.clone());
+
+        let mut decoder = reader
+            .into_decoder()
+            .context("Failed to construct image decoder")?;
+
+        // `ImageReader::decode` applies one extra allocation guard beyond
+        // `set_limits`'s dimension check: it reserves `decoder.total_bytes()`
+        // against `max_alloc` before any pixel data is decoded.
+        // `into_decoder` alone (needed here so orientation/ICC can be read
+        // off the decoder before it's consumed) skips that step, so it's
+        // replicated by hand to keep the exact same allocation guard #26
+        // relies on.
+        let mut reserved_limits = limits;
+        reserved_limits
+            .reserve(decoder.total_bytes())
+            .context("Failed to decode image")?;
+        decoder
+            .set_limits(reserved_limits)
+            .context("Failed to decode image")?;
+
+        let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+        let icc_profile = decoder.icc_profile().ok().flatten();
+
+        let img = image::DynamicImage::from_decoder(decoder).context("Failed to decode image")?;
+        Ok((img, orientation, icc_profile))
     }
 
     /// Explicit decode limits derived from the configured max source
@@ -1103,6 +1185,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 
@@ -2023,6 +2106,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background,
+            autorotate: true,
         }
     }
 
@@ -2378,6 +2462,169 @@ mod tests {
             out_lossy.len(),
             out_lossless.len(),
             "lossy and lossless webp encodes of the same photographic source should differ in size"
+        );
+    }
+
+    // ---- #33: EXIF autorotate ----
+
+    /// `fixtures::oriented(code)`'s marker sits in the top-left
+    /// `ORIENTED_MARKER`x`ORIENTED_MARKER` block of the *canonical*
+    /// (already-upright) image - see that fixture's doc comment. `(5, 5)`
+    /// is well inside it regardless of any JPEG-block-boundary blur from
+    /// decoding the lossy source.
+    fn assert_reddish(pixel: [u8; 3], context: &str) {
+        let [r, g, b] = pixel;
+        assert!(
+            r > 150 && i32::from(r) - i32::from(b) > 40,
+            "{context}: expected a reddish marker pixel, got {pixel:?} (r={r} g={g} b={b})"
+        );
+    }
+
+    /// Counterpart to `assert_reddish` for the canonical image's blue
+    /// background.
+    fn assert_blueish(pixel: [u8; 3], context: &str) {
+        let [r, g, b] = pixel;
+        assert!(
+            b > 150 && i32::from(b) - i32::from(r) > 40,
+            "{context}: expected a blueish background pixel, got {pixel:?} (r={r} g={g} b={b})"
+        );
+    }
+
+    /// #33: every one of the eight standard EXIF orientation values must
+    /// decode to the same upright `ORIENTED_W`x`ORIENTED_H` layout -
+    /// `fixtures::oriented`'s canonical marker (red top-left block on a
+    /// blue background) landing in the same place regardless of how the
+    /// source pixels were actually stored, dimensions included (5-8 swap
+    /// width/height in the stored file). No resize is requested here, so
+    /// this isolates autorotate itself from the resize/crop math the next
+    /// test covers.
+    #[test]
+    fn all_eight_exif_orientations_render_upright() {
+        let config = PerformanceConfig::default();
+
+        for code in 1u8..=8 {
+            let bytes = fixtures::oriented(code);
+            let params = ResizeQuery {
+                format: ApiImageFormat::Png,
+                ..query(None, None)
+            };
+
+            let (output, _content_type) =
+                ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                    .unwrap_or_else(|e| {
+                        panic!("orientation {code}: processing should succeed: {e}")
+                    });
+
+            let decoded = image::load_from_memory(&output)
+                .unwrap_or_else(|e| panic!("orientation {code}: output should decode: {e}"));
+            assert_eq!(
+                decoded.dimensions(),
+                (fixtures::ORIENTED_W, fixtures::ORIENTED_H),
+                "orientation {code}: expected the canonical upright dimensions"
+            );
+
+            let rgb = decoded.to_rgb8();
+            assert_reddish(
+                rgb.get_pixel(5, 5).0,
+                &format!("orientation {code}, marker corner"),
+            );
+            assert_blueish(
+                rgb.get_pixel(100, 70).0,
+                &format!("orientation {code}, background"),
+            );
+        }
+    }
+
+    /// #33: the order-of-operations case the issue explicitly calls out -
+    /// autorotate must be applied *before* resize, or a crop/scale composes
+    /// against the wrong axes. `fixtures::oriented(6)` is stored 90-degrees
+    /// rotated (80x120, portrait) under EXIF orientation 6; a `Fit` request
+    /// naming only a width is aspect-ratio-preserving against whatever
+    /// dimensions the resize step sees. If autorotation happened after
+    /// resize (or not at all), the resize would run against the stored
+    /// 80x120 portrait shape instead of the corrected 120x80 landscape one,
+    /// producing the wrong output dimensions and a sideways marker.
+    #[test]
+    fn rotated_source_with_resize_produces_correctly_oriented_output_at_right_dimensions() {
+        let bytes = fixtures::oriented(6); // stored 80x120, corrects to 120x80
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Png,
+            ..query(Some(60), None) // half-scale fit, preserving the corrected 3:2 aspect
+        };
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let decoded = image::load_from_memory(&output).expect("output should decode");
+        assert_eq!(
+            decoded.dimensions(),
+            (60, 40),
+            "expected the corrected (landscape) aspect ratio scaled to width 60, not the \
+             stored (portrait) shape"
+        );
+
+        let rgb = decoded.to_rgb8();
+        assert_reddish(rgb.get_pixel(3, 3).0, "resized marker corner");
+        assert_blueish(rgb.get_pixel(50, 35).0, "resized background");
+    }
+
+    /// #33: `autorotate: false` must leave the image exactly as stored -
+    /// the opt-out this crate's `ar:0` URL option (and imgproxy's own
+    /// `IMGPROXY_AUTO_ROTATE=false`) exists for. No resize is requested, so
+    /// the output dimensions must match the *stored* (portrait, un-rotated)
+    /// shape, not the corrected (landscape) one the previous two tests
+    /// assert.
+    #[test]
+    fn autorotate_disabled_leaves_image_as_stored() {
+        let bytes = fixtures::oriented(6); // stored 80x120
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            autorotate: false,
+            ..query(None, None)
+        };
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let decoded = image::load_from_memory(&output).expect("output should decode");
+        assert_eq!(
+            decoded.dimensions(),
+            (fixtures::ORIENTED_H, fixtures::ORIENTED_W),
+            "autorotate=false must leave the stored (portrait) dimensions untouched, not \
+             apply the EXIF correction"
+        );
+    }
+
+    /// #33: a source with no EXIF orientation tag at all must be completely
+    /// unaffected by `autorotate` - `fixtures::photo_like` carries no Exif
+    /// segment, so `decoder.orientation()` reports `NoTransforms` either
+    /// way and `apply_orientation` is a no-op regardless of the flag,
+    /// making output byte-for-byte identical between the two.
+    #[test]
+    fn images_without_orientation_tag_are_unaffected_by_autorotate() {
+        let bytes = fixtures::photo_like(); // 1920x1080, no Exif segment
+        let config = PerformanceConfig::default();
+
+        let with_autorotate = query_with_type(Some(300), Some(200), ResizeType::Fit);
+        let without_autorotate = ResizeQuery {
+            autorotate: false,
+            ..query_with_type(Some(300), Some(200), ResizeType::Fit)
+        };
+
+        let (output_on, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &with_autorotate, &config)
+                .expect("autorotate=true processing should succeed");
+        let (output_off, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &without_autorotate, &config)
+                .expect("autorotate=false processing should succeed");
+
+        assert_eq!(
+            output_on, output_off,
+            "a source with no EXIF orientation tag must produce identical output regardless \
+             of autorotate"
         );
     }
 }

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -497,6 +497,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 
@@ -574,6 +577,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -501,6 +501,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         });
 
         let mut handles = Vec::with_capacity(100);
@@ -581,6 +582,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         });
 
         let mut handles = Vec::with_capacity(20);

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -468,6 +468,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
         let key = cache.generate_key(&params);

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -472,6 +472,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
         let key = cache.generate_key(&params);
         assert!(


### PR DESCRIPTION
## Summary

EXIF orientation was parsed by the decoder, exposed by the API, and **never applied**. Phone photos — which store pixels landscape plus an orientation tag — came out sideways.

Closes #33, #5.

**Stacked on [#70](https://github.com/vaam-store/image-resizer/pull/70)** (quality). Review that first; this branch contains it.

## Order of operations is the whole fix

`apply_orientation` runs immediately after decode and **before** `src_width`/`src_height` are read:

```rust
if params.autorotate {
    img.apply_orientation(orientation);
}
let (src_width, src_height) = img.dimensions();
```

A Rotate90/270 swaps the axes. Applying it later would compose every resize-type branch (#59) and the upscale guard (#36) against the wrong ones — the image would be upright but cropped along the wrong dimension. Regression-tested with a 90°-rotated source *plus* a resize request, which is where that class of bug shows.

## Also

- **`ar:{0|1}`** — imgproxy's `auto_rotate` short code, defaulting to **on**, matching `IMGPROXY_AUTO_ROTATE`. Unlike `enlarge`/`grayscale`, which default off.
- **ICC colour profiles forwarded** for JPEG and PNG. Previously wide-gamut sources shifted colour. **WebP remains a real gap** — the `webp` crate 0.3.1 exposes no ICC API at all, so a profile is still dropped there. Reported rather than hand-patching libwebp container chunks.
- **The #26 allocation guard is preserved.** Decoding moved to `ImageReader::into_decoder` so orientation and ICC can be read before the decoder is consumed — but `into_decoder` skips the `limits.reserve(decoder.total_bytes())` call that `.decode()` performs. It is replicated manually; dropping it would reopen the decode-bomb hole.
- **Fixtures generate EXIF-tagged JPEGs deterministically** — the stored image is built as the algebraic inverse of `apply_orientation`'s own match arms, so all eight orientation codes are tested against a known-upright target. No committed binaries.

## Merge note

This and #70 were implemented independently from the same base and **both bumped `CACHE_KEY_VERSION` to 6**. Merged to **7**, carrying both field sets.

Both also rewrote the JPEG encode path — #70 for `new_with_quality`, this for `set_icc_profile`. Resolved as construct-with-quality → attach ICC → `write_with_encoder`, verified against `image` 0.25.10's vendored source for the correct call sequence.

## Verification

- `cargo check --features local_fs --bins --tests --benches` — 0 errors
- `cargo check --features s3` — 0 errors
- `cargo test --features local_fs` — **424 passed, 0 failed**
- `cargo test --features s3` — **414 passed, 0 failed**

Golden-image tests assert dimensions and pixel positions, not status codes: all eight orientations render upright; a rotated source with a resize lands at the right aspect; `ar:0` leaves the image as stored; untagged sources are byte-identical either way.

## Reviewer focus

1. **The orientation/dimension ordering** — the fix depends on it.
2. **The manual `limits.reserve`** in `decode_with_limits` — security-relevant, easy to lose in a refactor.
3. **The merged JPEG encoder sequence** — quality and ICC both have to survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
