### PR TITLE
perf: DCT-scaled JPEG decode via mozjpeg (#63 stage 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "image",
  "ipnet",
  "mimalloc",
+ "mozjpeg",
  "num_cpus",
  "opentelemetry 0.29.1",
  "opentelemetry-otlp",
@@ -2573,6 +2574,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mozjpeg"
+version = "0.10.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7891b80aaa86097d38d276eb98b3805d6280708c4e0a1e6f6aed9380c51fec9"
+dependencies = [
+ "arrayvec",
+ "bytemuck",
+ "libc",
+ "mozjpeg-sys",
+ "rgb",
+]
+
+[[package]]
+name = "mozjpeg-sys"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0dc668bf9bf888c88e2fb1ab16a406d2c380f1d082b20d51dd540ab2aa70c1"
+dependencies = [
+ "cc",
+ "dunce",
+ "libc",
+ "nasm-rs",
+]
+
+[[package]]
+name = "nasm-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706bf8a5e8c8ddb99128c3291d31bd21f4bcde17f0f4c20ec678d85c74faa149"
+dependencies = [
+ "jobserver",
+ "log",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +3544,9 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tower-http = { version = "0.6", features = ["compression-full", "cors"] }
 tokio = { version = "1", features = ["full"] }
 
 reqwest = { version = "0.12", features = ["json", "stream", "http2", "gzip"] } # Optimized HTTP client
-image = { version = "0.25", features = ["jpeg", "png", "webp"] } # Core image processing with specific formats
+image = { version = "0.25", features = ["jpeg", "png", "webp", "avif", "gif"] } # avif for #49; gif for animation groundwork
 num_cpus = "1.16" # CPU detection for optimal thread pool sizing
 bytes = "1.5" # Efficient byte handling
 futures = "0.3" # Stream processing utilities
@@ -107,6 +107,7 @@ hmac = "0.12"
 subtle = "2.6"
 base64 = "0.22"
 fast_image_resize = { version = "6.1", features = ["image"] }
+mozjpeg = "0.10"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,17 @@
 # `docker pull rust:1 && docker inspect rust:1 --format='{{index .RepoDigests 0}}'`.
 FROM rust@sha256:0e2bcaef56d041a486784e54104a81aebe0da44bd03019bd70bc0401e42e4a97 as builder
 
+# nasm is required by mozjpeg-sys (#63 stage 2) to build libjpeg-turbo's
+# x86_64 SIMD paths. It is NOT needed on aarch64, which uses its own NEON
+# path — but CI builds linux/amd64 as well as arm64, so it must be present
+# unconditionally. Without it the amd64 build either fails or silently falls
+# back to scalar C, which would quietly give up most of the 2.2x scaled-decode
+# win this dependency was added for.
+# DL3008 (pin apt versions) is ignored repo-wide in .hadolint.yaml.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends nasm \
+  && rm -rf /var/lib/apt/lists/*
+
 ENV APP_NAME=emgr
 
 WORKDIR /app

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+emgr
+Copyright (c) 2025 Stephane SEGNING LAMBOU
+
+Licensed under the MIT License. See LICENSE.
+
+--------------------------------------------------------------------------
+Third-party notices
+--------------------------------------------------------------------------
+
+This software is based in part on the work of the Independent JPEG Group.
+
+emgr links mozjpeg (via mozjpeg-sys), which vendors libjpeg-turbo and
+Independent JPEG Group code, distributed under the IJG, Zlib and
+BSD-3-Clause licences. It is used for DCT-scaled JPEG decoding.
+
+emgr also links libwebp (via the `webp` crate, BSD-3-Clause) for lossy WebP
+encoding.
+
+Full licence texts ship with those crates and are reproduced in the
+dependency tree under ~/.cargo/registry.

--- a/bench-imgproxy/driver/run.sh
+++ b/bench-imgproxy/driver/run.sh
@@ -32,7 +32,17 @@ if [ ! -f fixtures/corpus/photo_4k.jpg ]; then
 fi
 
 echo "==> Building and starting origin + minio (+ bucket init) + imgproxy + emgr + emgr_s3"
-docker compose up -d --build origin volume_init minio minio_init imgproxy emgr emgr_s3
+# Only bring up the engines actually being measured. Previously this list
+# was unconditional, so a run of just `imgproxy emgr` still built emgr_s3 —
+# and any unrelated build failure there aborted the whole sweep before a
+# single request was sent.
+services="origin volume_init"
+case " $ENGINES " in *" imgproxy "*) services="$services imgproxy";; esac
+case " $ENGINES " in *" emgr "*) services="$services emgr";; esac
+case " $ENGINES " in *" emgr_s3 "*) services="$services minio minio_init emgr_s3";; esac
+
+# shellcheck disable=SC2086 # word splitting is intended: $services is a list
+docker compose up -d --build $services
 
 echo "==> Waiting for origin, minio, imgproxy, emgr and emgr_s3 healthchecks"
 # #57: emgr/emgr_s3 are on the normal `bench` bridge network now (see

--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -26,6 +26,7 @@ fn bench_cache_key(c: &mut Criterion) {
         webp_quality: None,
         webp_lossless: None,
         background: None,
+        autorotate: true,
     };
 
     c.bench_function("cache_key/generate_key", |b| {

--- a/benches/cache_key.rs
+++ b/benches/cache_key.rs
@@ -22,6 +22,9 @@ fn bench_cache_key(c: &mut Criterion) {
         grayscale: Some(false),
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     };
 

--- a/benches/fixtures.rs
+++ b/benches/fixtures.rs
@@ -192,6 +192,111 @@ pub fn photo_like_sized(width: u32, height: u32, format: ImageFormat) -> Vec<u8>
     })
 }
 
+pub const ORIENTED_W: u32 = 120;
+pub const ORIENTED_H: u32 = 80;
+/// Marker block side length, in canonical (already-upright) pixels - well
+/// inside both the marker and background regions, so sampling a few pixels
+/// in from any edge lands solidly in one colour even after JPEG's lossy
+/// compression and any resize filtering a test applies on top.
+const ORIENTED_MARKER: u32 = 20;
+
+/// Canonical (already-upright) marker image used to build the EXIF-
+/// orientation fixtures below (#33): a deliberately non-square `W`x`H`
+/// image (so a 90/270-degree rotation bug shows up as a dimension swap, not
+/// just a same-shape pixel mismatch) with a solid red marker block in its
+/// top-left corner and solid blue everywhere else - "upright" here means
+/// exactly this layout.
+pub fn oriented_canonical() -> RgbImage {
+    ImageBuffer::from_fn(ORIENTED_W, ORIENTED_H, |x, y| {
+        if x < ORIENTED_MARKER && y < ORIENTED_MARKER {
+            Rgb([220, 30, 30]) // marker: red
+        } else {
+            Rgb([30, 30, 220]) // background: blue
+        }
+    })
+}
+
+/// Builds a minimal, valid Exif TIFF blob - the `APP1` payload *minus* the
+/// leading `"Exif\0\0"` marker, which `JpegEncoder::set_exif_metadata`
+/// prepends itself (image-0.25.10 `src/codecs/jpeg/encoder.rs::write_exif`)
+/// and the decode-side `zune-jpeg` strips back off before handing the
+/// remainder to `Orientation::from_exif_chunk` (`zune-jpeg-0.5.15`
+/// `src/headers.rs::parse_app1`) - containing exactly one IFD0 entry: the
+/// Orientation tag (`0x0112`, TIFF type 3/SHORT, count 1) set to
+/// `exif_orientation` (the standard 1-8 EXIF orientation code). Byte layout
+/// mirrors exactly what `Orientation::from_exif_chunk`'s
+/// `locate_orientation_entry` helper (image-0.25.10 `src/metadata.rs`)
+/// parses: little-endian TIFF header, one directory entry, no next-IFD.
+fn minimal_exif_orientation(exif_orientation: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(26);
+    buf.extend_from_slice(b"II"); // little-endian byte order
+    buf.extend_from_slice(&42u16.to_le_bytes()); // TIFF magic
+    buf.extend_from_slice(&8u32.to_le_bytes()); // IFD0 offset (right after this 8-byte header)
+    buf.extend_from_slice(&1u16.to_le_bytes()); // 1 directory entry
+    buf.extend_from_slice(&0x0112u16.to_le_bytes()); // tag: Orientation
+    buf.extend_from_slice(&3u16.to_le_bytes()); // type: SHORT
+    buf.extend_from_slice(&1u32.to_le_bytes()); // count: 1
+    buf.extend_from_slice(&u16::from(exif_orientation).to_le_bytes()); // value (low 2 bytes of the 4-byte value field)
+    buf.extend_from_slice(&0u16.to_le_bytes()); // padding (high 2 bytes of the value field)
+    buf.extend_from_slice(&0u32.to_le_bytes()); // next IFD offset: none
+    buf
+}
+
+/// A JPEG fixture whose *stored* pixel data is the algebraic inverse of
+/// [`oriented_canonical`]'s transform for EXIF orientation `exif_orientation`
+/// (1-8), tagged with that orientation in its Exif `Orientation` field -
+/// exactly how a real camera's sensor output plus its orientation sensor
+/// reading works: the pixels are stored however the sensor happened to be
+/// held, and the tag says how to correct them for display.
+///
+/// Correctly decoding + autorotating this fixture must reproduce
+/// `oriented_canonical()` exactly, dimensions included (orientations 5-8
+/// swap width and height). The inverse per code is derived directly from
+/// `DynamicImage::apply_orientation`'s own match arms (image-0.25.10
+/// `src/images/dynimage.rs:1161-1179`):
+///
+/// | code | `apply_orientation` forward transform | inverse used to build `stored` |
+/// |------|----------------------------------------|-------------------------------|
+/// | 1    | identity                                | identity                      |
+/// | 2    | `fliph`                                 | `fliph` (self-inverse)        |
+/// | 3    | `rotate180`                             | `rotate180` (self-inverse)    |
+/// | 4    | `flipv`                                 | `flipv` (self-inverse)        |
+/// | 5    | `fliph(rotate90(x))`                    | `rotate270(fliph(x))`         |
+/// | 6    | `rotate90(x)`                           | `rotate270(x)`                |
+/// | 7    | `fliph(rotate270(x))`                   | `rotate90(fliph(x))`          |
+/// | 8    | `rotate270(x)`                          | `rotate90(x)`                 |
+///
+/// so this is a from-first-principles inverse of the exact production
+/// transform, not a round-trip through it.
+pub fn oriented(exif_orientation: u8) -> Vec<u8> {
+    cached(&format!("oriented_{exif_orientation}.jpg"), || {
+        let canonical = DynamicImage::ImageRgb8(oriented_canonical());
+        let stored = match exif_orientation {
+            1 => canonical,
+            2 => canonical.fliph(),
+            3 => canonical.rotate180(),
+            4 => canonical.flipv(),
+            5 => canonical.fliph().rotate270(),
+            6 => canonical.rotate270(),
+            7 => canonical.fliph().rotate90(),
+            8 => canonical.rotate90(),
+            other => panic!("unsupported EXIF orientation value {other} (expected 1-8)"),
+        };
+
+        use image::ImageEncoder;
+
+        let mut buf = Cursor::new(Vec::new());
+        let mut encoder = image::codecs::jpeg::JpegEncoder::new(&mut buf);
+        encoder
+            .set_exif_metadata(minimal_exif_orientation(exif_orientation))
+            .expect("JpegEncoder supports Exif metadata");
+        stored
+            .write_with_encoder(encoder)
+            .expect("fixture encoding should never fail");
+        buf.into_inner()
+    })
+}
+
 /// content-type for a fixture identified by name, as served by the
 /// `benchmark` bin's local origin server and used to pick a decode/encode
 /// extension in tests.

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -12,6 +12,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use emgr::models::params::ImageFormat as ApiImageFormat;
 use emgr::models::params::{ResizeQuery, ResizeType};
 use emgr::services::image::handler::ImageService;
+use image::ImageFormat;
 
 fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> ResizeQuery {
     ResizeQuery {
@@ -36,8 +37,15 @@ fn bench_pipeline(c: &mut Criterion) {
     let photo = fixtures::photo_like();
     let flat = fixtures::flat();
     let alpha = fixtures::alpha();
+    // #63 stage 2: a large (4K) source downscaled to a small thumbnail -
+    // the exact shape of request the mozjpeg DCT-scaled decode targets, and
+    // the one the pre-stage-2 fixture set (topping out at 1920x1080, the
+    // `photo_like/thumbnail_jpg` case above) didn't cover. Matches the
+    // prototype measurement quoted in the #63 issue thread: 4K -> 200x113,
+    // decode + resize, 58.03ms (full decode) vs 26.21ms (1/8-scale decode).
+    let photo_4k = fixtures::photo_like_sized(3840, 2160, ImageFormat::Jpeg);
 
-    let cases: [(&str, &[u8], ResizeQuery); 3] = [
+    let cases: [(&str, &[u8], ResizeQuery); 4] = [
         (
             "photo_like/thumbnail_jpg",
             &photo,
@@ -52,6 +60,11 @@ fn bench_pipeline(c: &mut Criterion) {
             "alpha/resize_webp",
             &alpha,
             query(Some(256), Some(256), ApiImageFormat::Webp),
+        ),
+        (
+            "photo_4k/large_downscale_thumbnail_jpg",
+            &photo_4k,
+            query(Some(200), Some(113), ApiImageFormat::Jpg),
         ),
     ];
 

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -24,6 +24,9 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         grayscale: None,
         enlarge: false,
         quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
         background: None,
     }
 }

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -28,6 +28,7 @@ fn query(width: Option<u32>, height: Option<u32>, format: ApiImageFormat) -> Res
         webp_quality: None,
         webp_lossless: None,
         background: None,
+        autorotate: true,
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -58,6 +58,15 @@ allow = [
     # dependency to drop this (and the rest of the avif/rav1e stack)
     # entirely rather than allow-listing around it.
     "NCSA",
+
+    # mozjpeg / mozjpeg-sys (#63 stage 2), for DCT-scaled JPEG decode. IJG is
+    # permissive and OSI-recognised, but UNLIKE every other licence above it
+    # carries an actual obligation: distributed documentation must state that
+    # the software is "based in part on the work of the Independent JPEG
+    # Group". That notice is in README.md and NOTICE — if this allow-list
+    # entry is ever removed, remove the notice with it; if mozjpeg is kept,
+    # the notice must stay. Do not treat this as a routine allow-list add.
+    "IJG",
 ]
 confidence-threshold = 0.8
 

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -179,6 +179,26 @@ pub struct ResizeQuery {
     /// (PNG/WebP), so invisible pixels compress instead of carrying whatever
     /// garbage RGB the source had under `alpha=0` (#60).
     pub background: Option<[u8; 3]>,
+
+    /// Whether to rotate/flip the decoded image according to its EXIF
+    /// `Orientation` tag before any resize happens (#33; imgproxy's
+    /// `auto_rotate`/`ar` processing option -
+    /// <https://docs.imgproxy.net/usage/processing#auto-rotate>).
+    ///
+    /// Defaults to `true` - unlike every other boolean option on this
+    /// struct (`enlarge`, `grayscale`), matching imgproxy's own documented
+    /// default (`IMGPROXY_AUTO_ROTATE: true`): a phone photo's pixels are
+    /// stored sideways/upside-down as a matter of course, so leaving them
+    /// that way unless a caller opts in would produce the wrong output for
+    /// the common case, not just an unusual one.
+    ///
+    /// `ImageService::process_image_blocking_with_limits`
+    /// (`src/services/image/handler.rs`) applies this via
+    /// `DynamicImage::apply_orientation` immediately after decode and
+    /// before any resize/crop math - order matters, since a `Rotate90`/
+    /// `Rotate270` orientation swaps width and height, and applying it
+    /// after a crop would compose the crop against the wrong axes.
+    pub autorotate: bool,
 }
 
 /// Path parameter for the (unsigned, key-validated) download route

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -137,10 +137,35 @@ pub struct ResizeQuery {
     pub enlarge: bool,
 
     /// Output encode quality (imgproxy's `q:{0-100}` processing option).
-    /// `None` lets the encoder pick its own default. Threaded through for
-    /// the concurrently-landing lossy-WebP encoding work
-    /// (`src/services/image/handler.rs`, owned by another agent).
+    /// `None` lets the encoder pick its own default
+    /// (`ImageService::DEFAULT_JPEG_QUALITY` / `DEFAULT_WEBP_QUALITY`,
+    /// `src/services/image/handler.rs`). Overridden per-format by
+    /// `jpeg_quality`/`webp_quality` below when those are set (#35) -
+    /// mirrors imgproxy's own `q` (global) vs `format_quality` (per-format)
+    /// precedence (<https://docs.imgproxy.net/usage/processing#quality>).
     pub quality: Option<u8>,
+
+    /// Per-format quality override (imgproxy's `format_quality`/`fq:{format}:
+    /// {quality}:...` processing option, #35). Takes precedence over
+    /// `quality` for JPEG output when set - see
+    /// `ImageService::process_image_blocking_with_limits`
+    /// (`src/services/image/handler.rs`) for the exact precedence.
+    pub jpeg_quality: Option<u8>,
+
+    /// Per-format quality override for WebP output - see `jpeg_quality`
+    /// above for the general shape; same precedence over `quality`.
+    pub webp_quality: Option<u8>,
+
+    /// Encode WebP losslessly instead of lossily (imgproxy's `webp_options`/
+    /// `webpo:{compression}` processing option, #35 - only the `compression`
+    /// slot is implemented, see [`crate::modules::url::options`] for why).
+    /// `None`/`Some(false)` keeps the existing lossy path
+    /// (`ImageService::encode_webp`'s `lossless` parameter); `Some(true)`
+    /// encodes losslessly and ignores `quality`/`webp_quality` entirely,
+    /// matching `encode_webp`'s own "quality is used only when lossless is
+    /// false" contract. Meaningless (silently ignored) for non-WebP output,
+    /// same as every other format-specific option in this struct.
+    pub webp_lossless: Option<bool>,
 
     /// Background colour, as an `[R, G, B]` triple (imgproxy's
     /// `background`/`bg:{R}:{G}:{B}` or `bg:{hex}` processing option, #34).

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -271,6 +271,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }

--- a/src/modules/api/resize.rs
+++ b/src/modules/api/resize.rs
@@ -275,6 +275,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -118,6 +118,7 @@ impl ParsedRequest {
             webp_quality: self.options.webp_quality,
             webp_lossless: self.options.webp_lossless,
             background: self.options.background,
+            autorotate: self.options.autorotate.unwrap_or(true),
         }
     }
 }
@@ -155,8 +156,10 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
+        // Exercises every option the grammar accepts in one path, so a new
+        // option that silently fails to round-trip shows up here.
         let path = format!(
-            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp"
+            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/ar:0/{encoded}.webp"
         );
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
@@ -175,6 +178,7 @@ mod tests {
         assert!(query.enlarge);
         assert_eq!(query.format, ImageFormat::Webp);
         assert_eq!(query.background, Some([255, 0, 0]));
+        assert!(!query.autorotate, "ar:0 in the URL must disable autorotate");
     }
 
     #[test]
@@ -198,6 +202,10 @@ mod tests {
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);
         assert_eq!(query.background, None);
+        assert!(
+            query.autorotate,
+            "autorotate must default to true when no `ar` segment is present"
+        );
     }
 
     #[test]

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -114,6 +114,9 @@ impl ParsedRequest {
             grayscale: self.options.grayscale,
             enlarge: self.options.enlarge.unwrap_or(false),
             quality: self.options.quality,
+            jpeg_quality: self.options.jpeg_quality,
+            webp_quality: self.options.webp_quality,
+            webp_lossless: self.options.webp_lossless,
             background: self.options.background,
         }
     }
@@ -152,8 +155,9 @@ mod tests {
     #[test]
     fn full_grammar_round_trips_every_capability() {
         let encoded = b64("https://example.com/img.jpg");
-        let path =
-            format!("/SIG/rs:fill:300:300/q:80/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp");
+        let path = format!(
+            "/SIG/rs:fill:300:300/q:80/fq:webp:90/webpo:lossless/bl:5/g:true/el:1/bg:255:0:0/{encoded}.webp"
+        );
         let signed = split(&path).unwrap();
         let parsed = signed.parse().unwrap();
         let query = parsed.into_resize_query();
@@ -163,6 +167,9 @@ mod tests {
         assert_eq!(query.height, Some(300));
         assert_eq!(query.resize_type, crate::models::params::ResizeType::Fill);
         assert_eq!(query.quality, Some(80));
+        assert_eq!(query.webp_quality, Some(90));
+        assert_eq!(query.webp_lossless, Some(true));
+        assert_eq!(query.jpeg_quality, None);
         assert_eq!(query.blur_sigma, Some(5.0));
         assert_eq!(query.grayscale, Some(true));
         assert!(query.enlarge);
@@ -184,6 +191,9 @@ mod tests {
             crate::models::params::ResizeType::default()
         );
         assert_eq!(query.quality, None);
+        assert_eq!(query.jpeg_quality, None);
+        assert_eq!(query.webp_quality, None);
+        assert_eq!(query.webp_lossless, None);
         assert_eq!(query.blur_sigma, None);
         assert_eq!(query.grayscale, None);
         assert!(!query.enlarge);

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -6,8 +6,9 @@ use crate::models::params::ResizeType;
 /// own short option codes (`rs`, `q`, `bl`, `g`, `el`) so a client library
 /// written for imgproxy's URL format produces something this parser accepts
 /// for the capability set #53 keeps: width, height, resize type, blur,
-/// grayscale, enlarge, quality (format comes from the trailing
-/// `.{extension}` instead - see [`super::source`]).
+/// grayscale, enlarge, quality, per-format quality override, webp lossless
+/// (format comes from the trailing `.{extension}` instead - see
+/// [`super::source`]).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ProcessingOptions {
     pub width: Option<u32>,
@@ -21,6 +22,15 @@ pub struct ProcessingOptions {
     pub grayscale: Option<bool>,
     pub enlarge: Option<bool>,
     pub quality: Option<u8>,
+    /// `fq`'s parsed `jpg`/`jpeg` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::jpeg_quality`].
+    pub jpeg_quality: Option<u8>,
+    /// `fq`'s parsed `webp` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_quality`].
+    pub webp_quality: Option<u8>,
+    /// `webpo`'s parsed `compression` slot (#35) - see
+    /// [`crate::models::params::ResizeQuery::webp_lossless`].
+    pub webp_lossless: Option<bool>,
     /// `bg`'s parsed `[R, G, B]` triple (#34) - see
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
@@ -66,6 +76,81 @@ impl ProcessingOptions {
                 "q" => {
                     let [value] = require_args::<1>(&args, segment)?;
                     opts.quality = Some(parse_bounded(value, segment, 0, 100)?);
+                }
+                // fq:{format1}:{quality1}:{format2}:{quality2}:... - imgproxy's
+                // `format_quality`/`fq` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#format-quality>):
+                // "adds or redefines format_quality values" for the current
+                // request, on top of `q`'s global default. Only `jpg`/`jpeg`
+                // and `webp` are accepted - PNG output always uses this
+                // crate's fixed `CompressionType::Best` (no continuous 0-100
+                // quality knob exists to override), so `fq:png:N` is rejected
+                // with 400 rather than silently ignored. Repeating a format
+                // (`fq:jpg:80:jpg:90`) lets the later pair win, same as
+                // imgproxy's own "redefines" wording implies.
+                "fq" => {
+                    if args.is_empty() || !args.len().is_multiple_of(2) {
+                        return Err(UrlParseError::InvalidOptionValue {
+                            option: segment.to_string(),
+                            reason: "expected one or more format:quality pairs".to_string(),
+                        });
+                    }
+                    for pair in args.chunks(2) {
+                        let (format, value) = (pair[0], pair[1]);
+                        let quality = parse_bounded(value, segment, 0, 100)?;
+                        match format {
+                            "jpg" | "jpeg" => opts.jpeg_quality = Some(quality),
+                            "webp" => opts.webp_quality = Some(quality),
+                            "png" => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: "png has no adjustable quality in this encoder \
+                                             (PNG output always uses fixed CompressionType::Best)"
+                                        .to_string(),
+                                });
+                            }
+                            other => {
+                                return Err(UrlParseError::InvalidOptionValue {
+                                    option: segment.to_string(),
+                                    reason: format!(
+                                        "unsupported format {other:?} for format_quality \
+                                         (expected jpg, jpeg or webp)"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+                // webpo:{compression} - a deliberately partial implementation
+                // of imgproxy's `webp_options`/`webpo:{compression}:
+                // {smart_subsample}:{preset}` option (#35,
+                // <https://docs.imgproxy.net/usage/processing#webp-options>).
+                // Only the `compression` slot is implemented - the `webp`
+                // crate (0.3.1) this project depends on exposes exactly two
+                // encode modes, `Encoder::encode` (lossy) and
+                // `Encoder::encode_lossless`, with no `smart_subsample` or
+                // `preset` knob at all, and no `mixed` mode either. Requiring
+                // exactly one argument (rather than silently accepting and
+                // ignoring imgproxy's other two slots) is deliberate: a
+                // caller who actually needs `smart_subsample`/`preset` gets a
+                // clear 400 here instead of a silently-ignored parameter.
+                "webpo" => {
+                    let [compression] = require_args::<1>(&args, segment)?;
+                    opts.webp_lossless = Some(match compression {
+                        "lossy" => false,
+                        "lossless" => true,
+                        other => {
+                            return Err(UrlParseError::InvalidOptionValue {
+                                option: segment.to_string(),
+                                reason: format!(
+                                    "{other:?} is not a supported webp compression mode \
+                                     (expected lossy or lossless - this encoder has no \
+                                     mixed mode, and does not support imgproxy's \
+                                     smart_subsample/preset slots)"
+                                ),
+                            });
+                        }
+                    });
                 }
                 "bl" => {
                     let [value] = require_args::<1>(&args, segment)?;
@@ -285,6 +370,81 @@ mod tests {
     }
 
     #[test]
+    fn parses_format_quality_for_jpeg_and_webp() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:webp:90"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+    }
+
+    #[test]
+    fn format_quality_accepts_jpeg_alias() {
+        let opts = ProcessingOptions::parse(&["fq:jpeg:70"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(70));
+    }
+
+    #[test]
+    fn format_quality_later_pair_overrides_earlier_for_same_format() {
+        let opts = ProcessingOptions::parse(&["fq:jpg:80:jpg:40"]).unwrap();
+        assert_eq!(opts.jpeg_quality, Some(40));
+    }
+
+    #[test]
+    fn format_quality_rejects_png() {
+        assert!(ProcessingOptions::parse(&["fq:png:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_unknown_format() {
+        assert!(ProcessingOptions::parse(&["fq:avif:80"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_odd_argument_count() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:80:webp"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_out_of_range_value() {
+        assert!(ProcessingOptions::parse(&["fq:jpg:101"]).is_err());
+    }
+
+    #[test]
+    fn format_quality_rejects_empty_args() {
+        assert!(ProcessingOptions::parse(&["fq"]).is_err());
+    }
+
+    #[test]
+    fn parses_webp_lossless() {
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossless"])
+                .unwrap()
+                .webp_lossless,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["webpo:lossy"])
+                .unwrap()
+                .webp_lossless,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn webp_lossless_rejects_unsupported_mode() {
+        assert!(ProcessingOptions::parse(&["webpo:mixed"]).is_err());
+        assert!(ProcessingOptions::parse(&["webpo:nope"]).is_err());
+    }
+
+    #[test]
+    fn webp_lossless_rejects_extra_arguments() {
+        // imgproxy's own 3-slot grammar (compression:smart_subsample:preset)
+        // - this crate only implements the first slot, and rejects rather
+        // than silently ignoring the other two (see the `webpo` match arm's
+        // doc comment).
+        assert!(ProcessingOptions::parse(&["webpo:lossless::4"]).is_err());
+    }
+
+    #[test]
     fn parses_blur() {
         let opts = ProcessingOptions::parse(&["bl:5"]).unwrap();
         assert_eq!(opts.blur_sigma, Some(5.0));
@@ -327,6 +487,8 @@ mod tests {
         let opts = ProcessingOptions::parse(&[
             "rs:fill:300:300",
             "q:80",
+            "fq:webp:90",
+            "webpo:lossless",
             "bl:5",
             "g:true",
             "el:1",
@@ -337,6 +499,8 @@ mod tests {
         assert_eq!(opts.height, Some(300));
         assert_eq!(opts.resize_type, ResizeType::Fill);
         assert_eq!(opts.quality, Some(80));
+        assert_eq!(opts.webp_quality, Some(90));
+        assert_eq!(opts.webp_lossless, Some(true));
         assert_eq!(opts.blur_sigma, Some(5.0));
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -35,6 +35,12 @@ pub struct ProcessingOptions {
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
     pub background: Option<[u8; 3]>,
+    /// `ar`'s parsed boolean (#33) - see
+    /// [`crate::models::params::ResizeQuery::autorotate`]. `None` means
+    /// "use the default", which is `true` (autorotate stays on) unlike
+    /// every other `Option<bool>` field here - see `ResizeQuery::autorotate`'s
+    /// own doc comment for why.
+    pub autorotate: Option<bool>,
 }
 
 /// A processing-option path segment always contains a `:` (`rs:fill:300:300`,
@@ -169,6 +175,17 @@ impl ProcessingOptions {
                 // argument shapes.
                 "bg" => {
                     opts.background = Some(parse_background(&args, segment)?);
+                }
+                // ar:{0|1|true|false} - imgproxy's `auto_rotate`/`ar`
+                // processing option (#33,
+                // <https://docs.imgproxy.net/usage/processing#auto-rotate>):
+                // rotates/flips the decoded image per its EXIF orientation
+                // tag before any resize happens. Carried through to
+                // `ResizeQuery::autorotate`, defaulting to `true` when this
+                // segment is absent (see that field's doc comment).
+                "ar" => {
+                    let [value] = require_args::<1>(&args, segment)?;
+                    opts.autorotate = Some(parse_bool(value, segment)?);
                 }
                 other => return Err(UrlParseError::UnknownOption(other.to_string())),
             }
@@ -483,6 +500,32 @@ mod tests {
     }
 
     #[test]
+    fn parses_autorotate() {
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:1"]).unwrap().autorotate,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:0"]).unwrap().autorotate,
+            Some(false)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:true"]).unwrap().autorotate,
+            Some(true)
+        );
+        assert_eq!(
+            ProcessingOptions::parse(&["ar:false"]).unwrap().autorotate,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn autorotate_defaults_to_none_when_absent() {
+        let opts = ProcessingOptions::parse(&[]).unwrap();
+        assert_eq!(opts.autorotate, None);
+    }
+
+    #[test]
     fn combines_multiple_options() {
         let opts = ProcessingOptions::parse(&[
             "rs:fill:300:300",
@@ -493,6 +536,7 @@ mod tests {
             "g:true",
             "el:1",
             "bg:255:0:0",
+            "ar:0",
         ])
         .unwrap();
         assert_eq!(opts.width, Some(300));
@@ -505,6 +549,7 @@ mod tests {
         assert_eq!(opts.grayscale, Some(true));
         assert_eq!(opts.enlarge, Some(true));
         assert_eq!(opts.background, Some([255, 0, 0]));
+        assert_eq!(opts.autorotate, Some(false));
     }
 
     #[test]

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -30,8 +30,17 @@ use sha2::{Digest, Sha256};
 /// bytes. Now that it changes what gets encoded - both the flatten colour
 /// for alpha->no-alpha conversions and the fill colour for fully-transparent
 /// pixels when alpha is kept - two requests differing only in `background`
-/// must not collide onto a v4 key that never hashed it.
-const CACHE_KEY_VERSION: u8 = 5;
+/// must not collide onto a v4 key that never hashed it. v6 adds `quality`,
+/// `jpeg_quality`, `webp_quality` and `webp_lossless` (#35): `quality` was
+/// already parsed into `ResizeQuery` (from the URL grammar's `q:{0-100}`)
+/// before this change, but was never fed into `generate_key` at all - a
+/// pure oversight, not a deliberate "doesn't affect output" omission like
+/// `resize_type` was pre-#59, since quality has always affected encoded
+/// bytes for whatever encoder actually used it. Now that the encoders in
+/// `src/services/image/handler.rs` honour these fields, two requests
+/// differing only in quality/format-quality/losslessness must not collide
+/// onto a v5 key that never hashed any of them.
+const CACHE_KEY_VERSION: u8 = 6;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -104,6 +113,29 @@ impl CacheService {
         // Always-present (not `Option<bool>`, so no "None" bucket needed
         // here unlike `grayscale`/`blur_sigma`).
         Self::update_field(&mut hasher, params.enlarge.to_string().as_bytes());
+
+        // `quality`/`jpeg_quality`/`webp_quality`/`webp_lossless` (#35, v6)
+        // change the encoder's output bytes directly - see the v6
+        // `CACHE_KEY_VERSION` note above for why these were missing before.
+        match params.quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.jpeg_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_quality {
+            Some(quality) => Self::update_field(&mut hasher, &[quality]),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.webp_lossless {
+            Some(lossless) => Self::update_field(&mut hasher, lossless.to_string().as_bytes()),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
 
         // `background` (#34/#60, v5) changes the resize pipeline's output
         // bytes wherever alpha is flattened or transparent pixels are
@@ -192,6 +224,9 @@ mod tests {
             grayscale,
             enlarge,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -359,6 +394,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         };
 
@@ -371,6 +409,120 @@ mod tests {
             keys.len(),
             4,
             "each distinct background (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): `quality` changes the encoded output bytes, so
+    /// distinct qualities - and the unset ("use the encoder's default")
+    /// case - must not collide onto the same cache key.
+    #[test]
+    fn quality_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(30), Some(75), Some(90)]
+            .into_iter()
+            .map(|q| cache.generate_key(&base(q)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            4,
+            "each distinct quality (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #35 (v6 bump): a per-format quality override changes the encoded
+    /// output bytes independently of the global `quality`, so it must be
+    /// its own dimension in the cache key rather than being folded into (or
+    /// ignored relative to) `quality`.
+    #[test]
+    fn format_quality_produces_distinct_keys_from_global_quality() {
+        let cache = cache_service();
+
+        let base = |quality: Option<u8>, jpeg_quality: Option<u8>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality,
+            jpeg_quality,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+        };
+
+        let global_only = cache.generate_key(&base(Some(80), None));
+        let override_only = cache.generate_key(&base(None, Some(80)));
+        let both = cache.generate_key(&base(Some(80), Some(80)));
+        let neither = cache.generate_key(&base(None, None));
+
+        let keys: HashSet<String> = [
+            global_only.clone(),
+            override_only.clone(),
+            both.clone(),
+            neither.clone(),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            keys.len(),
+            4,
+            "quality and jpeg_quality must each be an independent cache-key dimension"
+        );
+    }
+
+    /// #35 (v6 bump): `webp_lossless` changes the encoded output bytes
+    /// (an entirely different codec path - `encode_lossless` vs `encode`),
+    /// so it must not collide with the lossy default.
+    #[test]
+    fn webp_lossless_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |webp_lossless: Option<bool>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Webp,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless,
+            background: None,
+        };
+
+        let keys: HashSet<String> = [None, Some(false), Some(true)]
+            .into_iter()
+            .map(|l| cache.generate_key(&base(l)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct webp_lossless value (including unset) must produce a distinct cache key"
         );
     }
 
@@ -396,6 +548,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
 

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -30,7 +30,7 @@ use sha2::{Digest, Sha256};
 /// bytes. Now that it changes what gets encoded - both the flatten colour
 /// for alpha->no-alpha conversions and the fill colour for fully-transparent
 /// pixels when alpha is kept - two requests differing only in `background`
-/// must not collide onto a v4 key that never hashed it. v6 adds `quality`,
+/// must not collide onto a v4 key that never hashed it. v7 adds `quality`,
 /// `jpeg_quality`, `webp_quality` and `webp_lossless` (#35): `quality` was
 /// already parsed into `ResizeQuery` (from the URL grammar's `q:{0-100}`)
 /// before this change, but was never fed into `generate_key` at all - a
@@ -40,7 +40,16 @@ use sha2::{Digest, Sha256};
 /// `src/services/image/handler.rs` honour these fields, two requests
 /// differing only in quality/format-quality/losslessness must not collide
 /// onto a v5 key that never hashed any of them.
-const CACHE_KEY_VERSION: u8 = 6;
+///
+/// v7 also adds
+/// `autorotate` (#33): before this, EXIF orientation was parsed but never
+/// applied, so every request produced un-rotated output regardless of
+/// `autorotate` and the field had no effect on output bytes. Now that a
+/// non-identity source orientation changes the output whenever autorotate
+/// is on, two requests differing only in `autorotate` - or any request
+/// against a since-fixed cache entry produced before this change existed at
+/// all - must not collide onto a v5 key that never hashed it.
+const CACHE_KEY_VERSION: u8 = 7;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -147,6 +156,13 @@ impl CacheService {
             None => Self::update_field(&mut hasher, b"None"),
         }
 
+        // `autorotate` (#33, v6) changes the resize pipeline's output
+        // whenever the source carries a non-identity EXIF orientation, so
+        // it must be part of the key like every other output-affecting
+        // field - see the v6 `CACHE_KEY_VERSION` note above. Always-present
+        // (not `Option<bool>`), so no "None" bucket is needed here.
+        Self::update_field(&mut hasher, params.autorotate.to_string().as_bytes());
+
         let result = hasher.finalize();
         format!("{:}{:x}.{}", self.minio_sub_path, result, params.format)
     }
@@ -228,6 +244,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 
@@ -376,6 +393,37 @@ mod tests {
         );
     }
 
+    /// #33 (v6 bump): `autorotate` changes the resize pipeline's output
+    /// whenever the source has a non-identity EXIF orientation, so two
+    /// requests differing only in `autorotate` must not collide onto the
+    /// same cache key.
+    #[test]
+    fn autorotate_true_and_false_produce_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |autorotate: bool| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            blur_sigma: None,
+            grayscale: None,
+            enlarge: false,
+            quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
+            background: None,
+            autorotate,
+        };
+
+        assert_ne!(
+            cache.generate_key(&base(true)),
+            cache.generate_key(&base(false))
+        );
+    }
+
     /// #34/#60 (v5 bump): `background` changes the resize pipeline's output
     /// bytes (flatten/normalise colour), so distinct backgrounds - and the
     /// unset ("use the default") case - must not collide onto the same
@@ -398,6 +446,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some([255, 255, 255]), Some([0, 0, 0]), Some([1, 2, 3])]
@@ -433,6 +482,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some(30), Some(75), Some(90)]
@@ -469,6 +519,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let global_only = cache.generate_key(&base(Some(80), None));
@@ -512,6 +563,7 @@ mod tests {
             webp_quality: None,
             webp_lossless,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [None, Some(false), Some(true)]
@@ -552,6 +604,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
 
         let keys: HashSet<String> = [

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -16,19 +16,31 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use url::Url;
 
-/// Placeholder lossy-WebP encode quality (0.0-100.0, libwebp's own scale).
-/// `ResizeQuery` (`src/models/params.rs`) now carries a real `quality:
-/// Option<u8>` field, parsed from the signed URL grammar's `q:{0-100}`
-/// processing option (#53/#27) - wiring it into the call site below instead
-/// of this placeholder is a one-line change (`ImageService::encode_webp`
-/// already accepts `quality`/`lossless` as plain parameters), just not made
-/// here since it's this file's own call to make. 82.0 is a commonly-cited
-/// "high quality, still meaningfully smaller than lossless" WebP setting.
+/// Default lossy-WebP encode quality (0.0-100.0, libwebp's own scale), used
+/// when neither `ResizeQuery::webp_quality` nor `ResizeQuery::quality` is
+/// set (#35). 82.0 is a commonly-cited "high quality, still meaningfully
+/// smaller than lossless" WebP setting, and is corroborated by
+/// `adr/0003-webp-measurement.md`'s matched-DSSIM sweep against the Kodak
+/// corpus: 82 falls between the measured q80 bucket (median WebP/JPEG size
+/// ratio 0.8497, n=23 images) and q85 bucket (0.8596, n=18), both inside the
+/// flat, no-crossover 40-85 range where WebP is consistently 15-19% smaller
+/// than JPEG at equal perceptual quality. That ADR explicitly re-checked
+/// this constant and requested no change.
 ///
 /// `pub` (like `encode_webp` itself) so `benches/encode.rs` can benchmark
 /// the exact default production uses instead of a hardcoded duplicate that
 /// could silently drift from it.
 pub const DEFAULT_WEBP_QUALITY: f32 = 82.0;
+
+/// Default JPEG encode quality (1-100, the `image` crate's own scale), used
+/// when neither `ResizeQuery::jpeg_quality` nor `ResizeQuery::quality` is
+/// set (#35). Matches `image::codecs::jpeg::JpegEncoder::new`'s own default
+/// (`image-0.25.10/src/codecs/jpeg/encoder.rs:392`, `new_with_quality(w,
+/// 75)`) - this crate's JPEG output already encoded at 75 before #35 (via
+/// `DynamicImage::write_to`'s default encoder construction), just without a
+/// named constant or a way to override it per-request. `adr/0003` measured
+/// against this exact default and requested no change to it either.
+pub const DEFAULT_JPEG_QUALITY: u8 = 75;
 
 /// Default background colour (#34) used both to flatten alpha before
 /// encoding to a format with no alpha channel, and as the fill colour for
@@ -571,11 +583,33 @@ impl ImageService {
         // for #60 that doesn't touch `Cargo.toml`: `PngEncoder` and its
         // `CompressionType`/`FilterType` enums are already part of the
         // `image` crate's own public API under the `png` feature this crate
-        // already depends on, not a new dependency. JPEG is unaffected and
-        // keeps going through `write_to` exactly as before.
+        // already depends on, not a new dependency. JPEG now uses an
+        // explicit `JpegEncoder::new_with_quality` (#35) instead of
+        // `write_to`'s implicit default-quality construction, so
+        // `params.quality`/`params.jpeg_quality` actually reach the encoder.
+        //
+        // PNG has no quality knob in `params` to honour - `CompressionType`
+        // is a fixed lossless setting, not a continuous 0-100 scale, and
+        // `fq:png:N` is rejected at parse time
+        // (`src/modules/url/options.rs`) rather than silently accepted and
+        // ignored here.
         let output_bytes = match output_format {
-            ImageFormat::WebP => Self::encode_webp(&img, DEFAULT_WEBP_QUALITY, false)
-                .context(format!("Failed to encode image to {:?}", output_format))?,
+            ImageFormat::WebP => {
+                let lossless = params.webp_lossless.unwrap_or(false);
+                // `quality` is meaningless (and unused by `encode_webp`)
+                // when `lossless` is set - see that function's own doc
+                // comment - but still resolved unconditionally here since
+                // that's simpler than threading an `Option` through just to
+                // skip computing a value nothing will read.
+                let quality = params
+                    .webp_quality
+                    .or(params.quality)
+                    .map(f32::from)
+                    .unwrap_or(DEFAULT_WEBP_QUALITY);
+
+                Self::encode_webp(&img, quality, lossless)
+                    .context(format!("Failed to encode image to {:?}", output_format))?
+            }
             ImageFormat::Png => {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
@@ -590,18 +624,28 @@ impl ImageService {
 
                 buf.into_inner()
             }
-            _ => {
-                // Pre-allocate buffer based on estimated size - only
-                // meaningful for the `write_to` path below; the WebP path
-                // above gets its output buffer from libwebp itself.
+            ImageFormat::Jpeg => {
+                let quality = params
+                    .jpeg_quality
+                    .or(params.quality)
+                    .unwrap_or(DEFAULT_JPEG_QUALITY);
+
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                img.write_to(&mut buf, output_format)
+                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
                 buf.into_inner()
             }
+            // `output_format` is only ever constructed from `params.format`
+            // (`crate::models::params::ImageFormat`, three variants: `Jpg`,
+            // `Png`, `Webp`) a few lines above, so every value the `match`
+            // above doesn't already handle is unreachable in practice - kept
+            // as a hard error rather than a silent generic `write_to` fallback
+            // so a future fourth format doesn't quietly skip quality handling.
+            other => anyhow::bail!("unsupported output format {other:?}"),
         };
 
         Ok((output_bytes, content_type.to_string()))
@@ -1055,6 +1099,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         }
     }
@@ -1972,6 +2019,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background,
         }
     }
@@ -2157,6 +2207,177 @@ mod tests {
             output.len() < 3_000,
             "expected flat-colour PNG under 3,000 bytes with Best compression, got {}",
             output.len()
+        );
+    }
+
+    // ---- #35: quality wiring (JpegEncoder::new_with_quality, encode_webp's
+    // quality/lossless parameters, per-format override, cache-key coverage
+    // for these tested separately in `src/services/cache/handler.rs`) ----
+
+    /// A lower JPEG quality must always produce a smaller (or equal, but in
+    /// practice smaller for a real photographic fixture) output than a
+    /// higher one, for the same source and dimensions - the whole point of
+    /// exposing the knob at all.
+    #[test]
+    fn jpeg_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Jpg,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// Same monotonicity property as `jpeg_quality_changes_output_size_monotonically`,
+    /// but through the lossy-WebP path (`Self::encode_webp`'s `quality`
+    /// parameter) instead of JPEG's.
+    #[test]
+    fn webp_quality_changes_output_size_monotonically() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+
+        let size_at = |quality: u8| {
+            let params = ResizeQuery {
+                format: ApiImageFormat::Webp,
+                quality: Some(quality),
+                ..query(Some(400), Some(300))
+            };
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed")
+                .0
+                .len()
+        };
+
+        let small = size_at(30);
+        let large = size_at(90);
+        assert!(
+            small < large,
+            "expected q=30 ({small} bytes) to be smaller than q=90 ({large} bytes)"
+        );
+    }
+
+    /// `jpeg_quality` (the `fq:jpg:{quality}` per-format override) must win
+    /// over the lower global `quality` - imgproxy's own documented
+    /// precedence for `format_quality` over `quality`.
+    #[test]
+    fn format_quality_override_beats_global_quality() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let global_low = ResizeQuery {
+            quality: Some(30),
+            ..base.clone()
+        };
+        let override_high = ResizeQuery {
+            quality: Some(30),
+            jpeg_quality: Some(90),
+            ..base
+        };
+
+        let (out_global, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &global_low, &config)
+                .expect("processing should succeed");
+        let (out_override, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &override_high, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            out_override.len() > out_global.len(),
+            "expected jpeg_quality=90 ({} bytes) to override the lower global quality=30 \
+             ({} bytes), producing larger output",
+            out_override.len(),
+            out_global.len()
+        );
+    }
+
+    /// Lossless WebP (`webp_lossless: Some(true)`) must round-trip the
+    /// source pixels exactly - no resize/blur/grayscale filter applied, and
+    /// a source with no alpha channel so the #34/#60 flatten/normalise
+    /// stage is a no-op, isolating this to purely the encoder's own
+    /// lossless-ness.
+    #[test]
+    fn webp_lossless_round_trips_byte_identical_pixels() {
+        let bytes = fixtures::photo_like(); // 1920x1080, no alpha channel
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            webp_lossless: Some(true),
+            ..query(None, None)
+        };
+
+        let (output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let original = image::load_from_memory(&bytes)
+            .expect("source should decode")
+            .to_rgba8();
+        let decoded = image::load_from_memory(&output)
+            .expect("lossless webp output should decode")
+            .to_rgba8();
+
+        assert_eq!(decoded.dimensions(), original.dimensions());
+        assert_eq!(
+            decoded.as_raw(),
+            original.as_raw(),
+            "lossless webp round-trip must be byte-identical to the source pixels"
+        );
+    }
+
+    /// Lossless WebP must actually take the `encode_lossless` path, not
+    /// merely happen to look identical - `lossless: Some(false)` (still
+    /// lossy) on the exact same source/dimensions must produce different
+    /// (and, for a real photographic fixture, larger) output, proving the
+    /// flag is wired through rather than a no-op that always round-trips
+    /// because e.g. quality was already 100.
+    #[test]
+    fn webp_lossless_differs_from_lossy_output() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Webp,
+            ..query(Some(400), Some(300))
+        };
+
+        let lossy = ResizeQuery {
+            webp_lossless: Some(false),
+            ..base.clone()
+        };
+        let lossless = ResizeQuery {
+            webp_lossless: Some(true),
+            ..base
+        };
+
+        let (out_lossy, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossy, &config)
+                .expect("processing should succeed");
+        let (out_lossless, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &lossless, &config)
+                .expect("processing should succeed");
+
+        assert_ne!(
+            out_lossy.len(),
+            out_lossless.len(),
+            "lossy and lossless webp encodes of the same photographic source should differ in size"
         );
     }
 }

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -15,6 +15,7 @@ use std::io::Cursor;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
+use tracing::warn;
 use url::Url;
 
 /// Default lossy-WebP encode quality (0.0-100.0, libwebp's own scale), used
@@ -425,7 +426,7 @@ impl ImageService {
         Self::check_source_resolution(src_width, src_height, config.max_src_resolution_mp)?;
 
         let (mut img, orientation, icc_profile) =
-            Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp)?;
+            Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp, params)?;
 
         // #33: autorotate (imgproxy's `auto_rotate`/`ar` option, on by
         // default - see `ResizeQuery::autorotate`) must be applied *before*
@@ -1029,6 +1030,41 @@ impl ImageService {
             .context("Failed to read image dimensions")
     }
 
+    /// Decodes `image_bytes`, enforcing every guard `decode_with_image_crate`
+    /// carries, with one addition (#63 stage 2): for JPEG, tries a DCT-scaled
+    /// decode through mozjpeg/libjpeg-turbo first, which can decode directly
+    /// at a fraction of the source resolution instead of always decoding
+    /// full-size and discarding most of the data during resize - see
+    /// `decode_jpeg_scaled`'s doc comment for the measured win. PNG and WebP
+    /// are untouched, always going straight to `decode_with_image_crate`.
+    ///
+    /// If the mozjpeg path fails for any reason - including a caught panic,
+    /// see `mozjpeg_decode` - this falls back to `decode_with_image_crate`
+    /// (the exact same full-decode path every non-JPEG format already uses)
+    /// rather than failing the request outright (#4), logging a warning so a
+    /// real regression in the mozjpeg path stays visible instead of quietly
+    /// becoming the normal path for every request.
+    fn decode_with_limits(
+        image_bytes: &[u8],
+        format: Option<ImageFormat>,
+        max_src_resolution_mp: u64,
+        params: &ResizeQuery,
+    ) -> Result<(image::DynamicImage, Orientation, Option<Vec<u8>>)> {
+        if format == Some(ImageFormat::Jpeg) {
+            match Self::decode_jpeg_scaled(image_bytes, max_src_resolution_mp, params) {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        "mozjpeg scaled JPEG decode failed; falling back to full image-crate decode"
+                    );
+                }
+            }
+        }
+
+        Self::decode_with_image_crate(image_bytes, format, max_src_resolution_mp)
+    }
+
     /// Decodes `image_bytes` with explicit `image::Limits` derived from
     /// `max_src_resolution_mp`, instead of inheriting the crate's
     /// accidental 512MiB `max_alloc` default (#26). This is defense in
@@ -1044,7 +1080,11 @@ impl ImageService {
     /// failing the whole request) if it can't be read - a source with
     /// malformed EXIF should still decode and process, just without
     /// autorotation.
-    fn decode_with_limits(
+    ///
+    /// This is the only decode path for PNG/WebP, and the fallback path for
+    /// JPEG when `decode_jpeg_scaled` (#63 stage 2) fails - see
+    /// `decode_with_limits`.
+    fn decode_with_image_crate(
         image_bytes: &[u8],
         format: Option<ImageFormat>,
         max_src_resolution_mp: u64,
@@ -1077,6 +1117,294 @@ impl ImageService {
 
         let img = image::DynamicImage::from_decoder(decoder).context("Failed to decode image")?;
         Ok((img, orientation, icc_profile))
+    }
+
+    /// JPEG-only DCT-scaled decode via mozjpeg/libjpeg-turbo (#63 stage 2):
+    /// decodes directly at a reduced resolution using libjpeg's native
+    /// `scale_num/8` support, instead of always decoding at full resolution
+    /// and discarding most of the data during resize. This is the large-
+    /// downscale path that drove the p90/p99 gap against imgproxy (see the
+    /// #63 issue thread) - measured 58.03ms (full decode + resize) vs
+    /// 26.21ms (1/8-scale decode + resize) for a 4K source to a 200x113
+    /// thumbnail, 2.21x.
+    ///
+    /// Every guard `decode_with_image_crate` carries is preserved here too.
+    /// An `image`-crate `ImageDecoder` is always opened first, purely to
+    /// read the header:
+    /// - #26's allocation guard (`Limits::reserve` against
+    ///   `decoder.total_bytes()`) is applied to it before any pixel data is
+    ///   decoded through *either* decoder below. (#26's *resolution* check
+    ///   itself already ran in the caller, against the header-peeked
+    ///   dimensions, before `decode_with_limits` is ever reached - not
+    ///   repeated here.)
+    /// - #33's EXIF orientation and ICC profile are read off it too.
+    ///
+    /// If `select_jpeg_dct_scale` decides no DCT reduction is safe/useful
+    /// for this request (`scale_num == 8`), this decoder is then reused
+    /// directly for the actual pixel decode - the exact same
+    /// `image::DynamicImage::from_decoder` call `decode_with_image_crate`
+    /// makes - rather than opening mozjpeg for zero benefit and risking a
+    /// gratuitous pixel-value difference from a second decoder's rounding.
+    /// Only when a real DCT scale is chosen does this drop the `image`-crate
+    /// decoder and hand off to mozjpeg. See `select_jpeg_dct_scale` for how
+    /// the scale factor itself is chosen - the "never decode smaller than
+    /// the target" requirement lives there.
+    fn decode_jpeg_scaled(
+        image_bytes: &[u8],
+        max_src_resolution_mp: u64,
+        params: &ResizeQuery,
+    ) -> Result<(DynamicImage, Orientation, Option<Vec<u8>>)> {
+        let mut reader = Self::make_reader(image_bytes, Some(ImageFormat::Jpeg))?;
+        let limits = Self::build_decode_limits(max_src_resolution_mp);
+        reader.limits(limits.clone());
+
+        let mut decoder = reader
+            .into_decoder()
+            .context("Failed to construct image decoder for header read")?;
+
+        // Same allocation guard as `decode_with_image_crate` - see that
+        // function's doc comment. Applied here even though this decoder
+        // never decodes a pixel: it's the cheapest possible place to keep
+        // the guard, and keeps this path's defense-in-depth identical to
+        // the fallback's.
+        let mut reserved_limits = limits;
+        reserved_limits
+            .reserve(decoder.total_bytes())
+            .context("Failed to decode image")?;
+        decoder
+            .set_limits(reserved_limits)
+            .context("Failed to decode image")?;
+
+        let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+        let icc_profile = decoder.icc_profile().ok().flatten();
+        let (header_width, header_height) = decoder.dimensions();
+
+        // `Orientation::Rotate90`/`Rotate270`/`Rotate90FlipH`/`Rotate270FlipH`
+        // swap width and height when applied (see `DynamicImage::apply_orientation`,
+        // image-0.25.10 `src/images/dynimage.rs:1161-1179`) - mirrored here
+        // via `axis_swap` so every dimension computed below is in the same
+        // axis space the *real* resize stage will see. Gated on
+        // `params.autorotate`: when it's off, orientation is never applied
+        // (see the call site in `process_image_blocking_with_limits`), so
+        // the image stays in its raw axes regardless of what the EXIF tag
+        // says.
+        let axis_swap = params.autorotate
+            && matches!(
+                orientation,
+                Orientation::Rotate90
+                    | Orientation::Rotate270
+                    | Orientation::Rotate90FlipH
+                    | Orientation::Rotate270FlipH
+            );
+
+        // The dimensions the resize stage will actually see, i.e. what
+        // `img.dimensions()` reports right after `apply_orientation` in
+        // `process_image_blocking_with_limits` (that call site's own
+        // `src_width`/`src_height`).
+        let (post_orientation_width, post_orientation_height) = if axis_swap {
+            (header_height, header_width)
+        } else {
+            (header_width, header_height)
+        };
+
+        let (target_width, target_height) = Self::effective_resize_target(
+            post_orientation_width,
+            post_orientation_height,
+            params,
+        );
+
+        // Map the target back into the JPEG's raw (pre-rotation) axis space:
+        // mozjpeg's `scale()` operates on the raw raster as stored in the
+        // file, before any EXIF rotation - that correction happens
+        // afterwards, in Rust, exactly as it already did before this change
+        // (`img.apply_orientation(orientation)` in
+        // `process_image_blocking_with_limits`).
+        let (raw_target_width, raw_target_height) = if axis_swap {
+            (target_height, target_width)
+        } else {
+            (target_width, target_height)
+        };
+
+        let scale_num = Self::select_jpeg_dct_scale(
+            header_width,
+            header_height,
+            raw_target_width,
+            raw_target_height,
+        );
+
+        // `scale_num == 8` means no DCT reduction is safe/useful for this
+        // request (either no resize was requested at all, or the requested
+        // output is close enough to source resolution that even the
+        // gentlest 1/2 scale would decode below target) - mozjpeg would buy
+        // nothing here, so decode through the already-open `image`-crate
+        // decoder instead of opening a second decoder over the same bytes.
+        // This also keeps output byte-for-byte identical to
+        // `decode_with_image_crate` for every request that isn't actually
+        // downscaling, rather than introducing a second JPEG decoder's
+        // slightly different IDCT/chroma-upsampling rounding into a path
+        // that was never going to benefit from mozjpeg anyway.
+        if scale_num == 8 {
+            let img =
+                image::DynamicImage::from_decoder(decoder).context("Failed to decode image")?;
+            return Ok((img, orientation, icc_profile));
+        }
+        drop(decoder);
+
+        let img = Self::mozjpeg_decode(image_bytes, scale_num)?;
+
+        Ok((img, orientation, icc_profile))
+    }
+
+    /// Predicts the exact target dimensions the resize stage in
+    /// `process_image_blocking_with_limits` (its `effective_width`/
+    /// `effective_height` computation and the `Fit`/`Fill`/`Force`/`Auto`
+    /// match right after it) will compute for a decoded (and, if
+    /// `params.autorotate` is set, already-rotated) image of
+    /// `src_width x src_height` - the #36 upscale guard and every resize-type
+    /// branch, reproduced verbatim from that call site, sharing the same
+    /// `resize_dimensions` aspect-ratio helper so the two can't drift on the
+    /// underlying arithmetic.
+    ///
+    /// Exists so `decode_jpeg_scaled` (#63 stage 2) can pick a DCT scale
+    /// *before* decoding, without duplicating the real resize call itself.
+    /// If this function and the real resize stage are ever changed
+    /// independently of each other, `decode_jpeg_scaled` could end up
+    /// picking a scale that decodes below what the real resize needs -
+    /// violating the "never decode smaller than target" requirement - so
+    /// keep them in sync.
+    fn effective_resize_target(src_width: u32, src_height: u32, params: &ResizeQuery) -> (u32, u32) {
+        let effective_width = params
+            .width
+            .map(|w| if params.enlarge { w } else { w.min(src_width) });
+        let effective_height = params
+            .height
+            .map(|h| if params.enlarge { h } else { h.min(src_height) });
+
+        match (effective_width, effective_height) {
+            (Some(w), None) => Self::resize_dimensions(src_width, src_height, w, u32::MAX, false),
+            (None, Some(h)) => Self::resize_dimensions(src_width, src_height, u32::MAX, h, false),
+            (Some(w), Some(h)) => match params.resize_type {
+                ResizeType::Fit => Self::resize_dimensions(src_width, src_height, w, h, false),
+                // `Fill` resizes to the *intermediate* (pre-crop) cover size
+                // before cropping down to exactly `w x h` (see
+                // `fir_resize_to_fill`) - that intermediate size, not the
+                // final `w x h` box, is the real minimum decode requirement:
+                // decoding only as small as the post-crop box would force
+                // the intermediate resize step to upscale back up.
+                ResizeType::Fill => Self::resize_dimensions(src_width, src_height, w, h, true),
+                ResizeType::Force => (w.max(1), h.max(1)),
+                ResizeType::Auto => {
+                    let src_landscape = src_width >= src_height;
+                    let dst_landscape = w >= h;
+                    Self::resize_dimensions(
+                        src_width,
+                        src_height,
+                        w,
+                        h,
+                        src_landscape == dst_landscape,
+                    )
+                }
+            },
+            // No resize requested at all - the decoded image is the output,
+            // so nothing smaller than full resolution is safe.
+            (None, None) => (src_width, src_height),
+        }
+    }
+
+    /// Picks the most aggressive libjpeg DCT scale (`scale_num/8`, see
+    /// `mozjpeg::Decompress::scale`) whose decoded output is still `>=` the
+    /// requested target in *both* dimensions - i.e. the smallest safe
+    /// decode. Never returns a scale that would decode smaller than
+    /// `target_width`/`target_height`: doing so would force
+    /// `fast_image_resize` to upscale back up before its final downscale,
+    /// destroying quality for no benefit (the whole point of this function).
+    ///
+    /// libjpeg-turbo supports any `scale_num` in 1..=16 (any N/8), but only
+    /// the well-known fractions are tried here - 1/8, 1/4, 1/2, and 8/8 (no
+    /// scaling) - the useful ratios for shrink-on-load per #63 stage 2.
+    /// Tried from most to least aggressive, so the first match is the
+    /// smallest valid decode; falls through to 8 (full resolution, i.e. no
+    /// DCT scaling at all) if even 1/2 would decode below target - which is
+    /// always the outcome when no resize was requested at all, since
+    /// `effective_resize_target`'s `(None, None)` branch sets the target to
+    /// the full source size.
+    fn select_jpeg_dct_scale(
+        raw_width: u32,
+        raw_height: u32,
+        target_width: u32,
+        target_height: u32,
+    ) -> u8 {
+        for scale_num in [1u8, 2, 4] {
+            let scaled_width = Self::mozjpeg_scaled_dimension(raw_width, scale_num);
+            let scaled_height = Self::mozjpeg_scaled_dimension(raw_height, scale_num);
+            if scaled_width >= target_width && scaled_height >= target_height {
+                return scale_num;
+            }
+        }
+        8
+    }
+
+    /// Reproduces libjpeg's own output-size formula for a scaled decode -
+    /// `jdiv_round_up(dim * scale_num, 8)` (`jdiv_round_up` in libjpeg-turbo's
+    /// `jutils.c`, used by `jdmaster.c`'s `jinit_master_decompress` to set
+    /// `output_width`/`output_height`) - exactly, so this prediction matches
+    /// what `Decompress::scale` will actually produce.
+    fn mozjpeg_scaled_dimension(dim: u32, scale_num: u8) -> u32 {
+        ((u64::from(dim) * u64::from(scale_num) + 7) / 8) as u32
+    }
+
+    /// Runs the actual mozjpeg/libjpeg-turbo pixel decode at `scale_num/8`
+    /// scale, producing an `Rgb8` `DynamicImage`.
+    ///
+    /// Wrapped in `catch_unwind`: mozjpeg's error manager (see the
+    /// `mozjpeg` crate's `errormgr.rs::unwind_error_exit`, which this crate
+    /// vendors as a dependency but does not modify) deliberately *unwinds*
+    /// on a fatal libjpeg error rather than returning an `Err` - upstream's
+    /// documented behaviour, not a bug. Left uncaught, that panic would
+    /// bypass `decode_jpeg_scaled`'s `Result`-based error handling entirely
+    /// and skip straight past the graceful-fallback path #4 requires.
+    /// `catch_unwind` turns it into a normal `Err` here so a malformed or
+    /// hostile JPEG that trips it falls back to `decode_with_image_crate`
+    /// exactly like any other mozjpeg failure - `Cargo.toml`'s
+    /// `panic = "unwind"` (kept specifically for #29, decoding untrusted
+    /// input) is what makes this catchable at all, rather than aborting the
+    /// process. `AssertUnwindSafe` is sound here: `image_bytes` is a shared
+    /// `&[u8]` with no interior mutability to leave torn, and `scale_num` is
+    /// `Copy`.
+    fn mozjpeg_decode(image_bytes: &[u8], scale_num: u8) -> Result<DynamicImage> {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Self::mozjpeg_decode_inner(image_bytes, scale_num)
+        }))
+        .unwrap_or_else(|payload| {
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_string()))
+                .unwrap_or_else(|| "mozjpeg panicked with a non-string payload".to_string());
+            Err(anyhow::anyhow!("mozjpeg decode panicked: {msg}"))
+        })
+    }
+
+    fn mozjpeg_decode_inner(image_bytes: &[u8], scale_num: u8) -> Result<DynamicImage> {
+        let mut decompress = mozjpeg::Decompress::new_mem(image_bytes)
+            .context("mozjpeg: failed to read JPEG header")?;
+        decompress.scale(scale_num);
+
+        let mut started = decompress
+            .rgb()
+            .context("mozjpeg: failed to start decompression")?;
+        let width = started.width() as u32;
+        let height = started.height() as u32;
+        let pixels: Vec<u8> = started
+            .read_scanlines()
+            .context("mozjpeg: failed to read scanlines")?;
+        started
+            .finish()
+            .context("mozjpeg: failed to finish decompression")?;
+
+        image::RgbImage::from_raw(width, height, pixels)
+            .map(DynamicImage::ImageRgb8)
+            .context("mozjpeg: decoded pixel buffer size did not match reported dimensions")
     }
 
     /// Explicit decode limits derived from the configured max source
@@ -1258,6 +1586,215 @@ mod tests {
         let img = image::DynamicImage::new_rgb8(1, 1);
         let size = ImageService::estimate_output_size(&img, &ImageFormat::Png);
         assert_eq!(size, 4);
+    }
+
+    // ---- #63 stage 2: mozjpeg DCT-scaled decode ----
+
+    /// `mozjpeg_scaled_dimension` must reproduce libjpeg's own
+    /// `jdiv_round_up(dim * scale_num, 8)` ceiling formula exactly, or the
+    /// scale planner in `select_jpeg_dct_scale` could mispredict what
+    /// `Decompress::scale` actually produces.
+    #[test]
+    fn mozjpeg_scaled_dimension_matches_libjpeg_ceil_formula() {
+        // 1/8 scale of 3840 is an exact 480, no rounding involved.
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(3840, 1), 480);
+        // 1/4 and 1/2 of the same source.
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(3840, 2), 960);
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(3840, 4), 1920);
+        // Full resolution (8/8) is a no-op.
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(3840, 8), 3840);
+        // A dimension libjpeg's ceiling rounds up rather than truncates:
+        // 1000 * 1 / 8 = 125.0 exactly, but 1001 * 1 / 8 = 125.125, which
+        // must round *up* to 126, not truncate to 125.
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(1001, 1), 126);
+        // Degenerate 1px source must never round down to 0.
+        assert_eq!(ImageService::mozjpeg_scaled_dimension(1, 1), 1);
+    }
+
+    /// For a large source and a small target, `select_jpeg_dct_scale` must
+    /// pick the most aggressive (smallest numerator) scale that still meets
+    /// the target - this is the entire performance win of #63 stage 2.
+    #[test]
+    fn select_jpeg_dct_scale_picks_most_aggressive_safe_reduction() {
+        // 3840x2160 (4K) -> 200x113 thumbnail: even 1/8 scale (480x270)
+        // comfortably covers the target, so the most aggressive scale wins.
+        assert_eq!(ImageService::select_jpeg_dct_scale(3840, 2160, 200, 113), 1);
+
+        // A target that only 1/4 scale (960x540), not 1/8 (480x270), can
+        // cover.
+        assert_eq!(ImageService::select_jpeg_dct_scale(3840, 2160, 700, 400), 2);
+
+        // A target only 1/2 scale (1920x1080) can cover.
+        assert_eq!(
+            ImageService::select_jpeg_dct_scale(3840, 2160, 1800, 1000),
+            4
+        );
+
+        // A target close to full source resolution - no scale below full
+        // (8) is safe.
+        assert_eq!(
+            ImageService::select_jpeg_dct_scale(3840, 2160, 3800, 2140),
+            8
+        );
+
+        // No resize at all (target == source, `effective_resize_target`'s
+        // `(None, None)` case) must never scale down.
+        assert_eq!(
+            ImageService::select_jpeg_dct_scale(3840, 2160, 3840, 2160),
+            8
+        );
+    }
+
+    /// Property check standing in for an exhaustive one: across a spread of
+    /// source/target combinations, the scale `select_jpeg_dct_scale` picks
+    /// must never decode smaller than the target in either axis - the exact
+    /// safety requirement #63 stage 2 depends on (decoding below target
+    /// would force `fast_image_resize` to upscale back up before its final
+    /// downscale, destroying quality for no benefit).
+    #[test]
+    fn select_jpeg_dct_scale_never_decodes_below_target() {
+        let sources = [(320, 240), (1920, 1080), (3840, 2160), (7000, 5000)];
+        let target_fractions = [1, 2, 3, 5, 7, 8];
+
+        for (raw_w, raw_h) in sources {
+            for &num in &target_fractions {
+                let target_w = raw_w * num / 8;
+                let target_h = raw_h * num / 8;
+                let scale = ImageService::select_jpeg_dct_scale(raw_w, raw_h, target_w, target_h);
+
+                let scaled_w = ImageService::mozjpeg_scaled_dimension(raw_w, scale);
+                let scaled_h = ImageService::mozjpeg_scaled_dimension(raw_h, scale);
+
+                assert!(
+                    scaled_w >= target_w && scaled_h >= target_h,
+                    "source {raw_w}x{raw_h}, target {target_w}x{target_h}: chosen scale {scale}/8 \
+                     decoded to {scaled_w}x{scaled_h}, which is smaller than the target in at \
+                     least one axis"
+                );
+            }
+        }
+    }
+
+    /// `effective_resize_target` must mirror the real resize stage's own
+    /// `Fit`/`Fill` target math (`resize_dimensions` with `fill: false`/
+    /// `true` respectively) - this pins the two together so they can't
+    /// silently drift, which is the entire correctness argument for using
+    /// this function to plan a DCT scale ahead of decode.
+    #[test]
+    fn effective_resize_target_matches_resize_dimensions_for_fit_and_fill() {
+        let params_fit = query_with_type(Some(800), Some(600), ResizeType::Fit);
+        assert_eq!(
+            ImageService::effective_resize_target(1920, 1080, &params_fit),
+            ImageService::resize_dimensions(1920, 1080, 800, 600, false)
+        );
+
+        let params_fill = query_with_type(Some(800), Some(600), ResizeType::Fill);
+        assert_eq!(
+            ImageService::effective_resize_target(1920, 1080, &params_fill),
+            ImageService::resize_dimensions(1920, 1080, 800, 600, true)
+        );
+
+        // `Force` ignores aspect ratio entirely - exact target, not a
+        // `resize_dimensions` call.
+        let params_force = query_with_type(Some(800), Some(600), ResizeType::Force);
+        assert_eq!(
+            ImageService::effective_resize_target(1920, 1080, &params_force),
+            (800, 600)
+        );
+
+        // No resize requested - the full source is the target, so no DCT
+        // scale should ever be selected against it.
+        let params_none = query(None, None);
+        assert_eq!(
+            ImageService::effective_resize_target(1920, 1080, &params_none),
+            (1920, 1080)
+        );
+    }
+
+    /// The #36 upscale guard must still apply inside the DCT-scale planner:
+    /// requesting an output larger than the source, with `enlarge` left at
+    /// its default `false`, must predict a target capped at the source
+    /// resolution - never a target that would make `select_jpeg_dct_scale`
+    /// think a smaller-than-source decode is unsafe when it's actually fine.
+    #[test]
+    fn effective_resize_target_honours_the_upscale_guard() {
+        let params = query(Some(5000), Some(5000));
+        assert_eq!(
+            ImageService::effective_resize_target(1920, 1080, &params),
+            (1920, 1080),
+            "expected the target capped at the source resolution, matching the #36 guard"
+        );
+    }
+
+    /// `mozjpeg_decode` wraps the actual libjpeg-turbo call in
+    /// `catch_unwind` because mozjpeg's error manager unwinds (panics) on a
+    /// fatal libjpeg error rather than returning `Err` (see that function's
+    /// doc comment) - bytes with no valid JPEG SOI marker at all trip
+    /// exactly this path (libjpeg's `read_markers` calls `ERREXIT` for "Not
+    /// a JPEG file" unconditionally, not gated behind the `require_image`
+    /// flag `Decompress::read_header` otherwise relies on). This must come
+    /// back as a normal `Err`, not tear down the test process - proving the
+    /// safety net #4 depends on (graceful fallback rather than a panic
+    /// escaping past `decode_jpeg_scaled`) actually works, not just that it
+    /// compiles.
+    #[test]
+    fn mozjpeg_decode_returns_err_instead_of_panicking_on_non_jpeg_bytes() {
+        let garbage = vec![0u8; 256];
+        let result = ImageService::mozjpeg_decode(&garbage, 8);
+        assert!(
+            result.is_err(),
+            "expected a graceful Err for non-JPEG bytes, not a panic or success"
+        );
+    }
+
+    /// End-to-end: a corrupt-but-JPEG-tagged source (valid SOI marker so
+    /// `detect_format_from_bytes` picks the JPEG path, garbage after it)
+    /// must still surface as a clean `Err` from the full pipeline entry
+    /// point - covering both `decode_jpeg_scaled`'s own early failure (its
+    /// header-only `image`-crate read also can't parse this) and, via
+    /// `decode_with_limits`, the fallback to `decode_with_image_crate`,
+    /// which fails the same way. Neither failure should panic the calling
+    /// thread.
+    #[test]
+    fn corrupt_jpeg_tagged_source_fails_cleanly_through_the_full_pipeline() {
+        let mut bytes = vec![0xFFu8, 0xD8, 0xFF, 0xE0]; // valid JPEG SOI + APP0 marker start
+        bytes.extend(std::iter::repeat_n(0u8, 64)); // garbage instead of a real header
+        let config = PerformanceConfig::default();
+        let params = query(Some(100), Some(100));
+
+        let result = ImageService::process_image_blocking_with_limits(&bytes, &params, &config);
+        assert!(
+            result.is_err(),
+            "expected a clean error for a corrupt JPEG-tagged source, not a panic or success"
+        );
+    }
+
+    /// #63 stage 2's actual target scenario: a large (4K) source downscaled
+    /// to a small thumbnail. This is exactly the shape of request that
+    /// should select an aggressive DCT scale (see
+    /// `select_jpeg_dct_scale_picks_most_aggressive_safe_reduction`) and
+    /// decode through mozjpeg rather than the full-resolution fallback -
+    /// asserted here indirectly, through the one thing that must never be
+    /// wrong regardless of which decoder produced the pixels: the final
+    /// output dimensions, which must match what `resize_dimensions` (the
+    /// same aspect-ratio math the non-scaled path already uses) predicts.
+    #[test]
+    fn large_downscale_through_mozjpeg_produces_correct_output_dimensions() {
+        let bytes = fixtures::photo_like_sized(3840, 2160, ImageFormat::Jpeg);
+        let config = PerformanceConfig::default();
+        let params = query_with_type(Some(200), Some(113), ResizeType::Fit);
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing a large downscale should succeed");
+
+        let decoded = image::load_from_memory(&output).expect("output should decode");
+        let expected = ImageService::resize_dimensions(3840, 2160, 200, 113, false);
+        assert_eq!(
+            decoded.dimensions(),
+            expected,
+            "expected the same Fit target dimensions the non-scaled path would produce"
+        );
     }
 
     /// #36: requesting a much larger output than a tiny source, with

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -7,7 +7,8 @@ use derive_builder::Builder;
 use fast_image_resize as fir;
 use futures::StreamExt;
 use image::imageops::FilterType;
-use image::{DynamicImage, GenericImageView, ImageFormat};
+use image::metadata::Orientation;
+use image::{DynamicImage, GenericImageView, ImageDecoder, ImageEncoder, ImageFormat};
 use reqwest::redirect::Policy;
 use reqwest::{Client, Response};
 use std::io::Cursor;
@@ -423,7 +424,20 @@ impl ImageService {
         let (src_width, src_height) = Self::peek_dimensions(image_bytes, format)?;
         Self::check_source_resolution(src_width, src_height, config.max_src_resolution_mp)?;
 
-        let img = Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp)?;
+        let (mut img, orientation, icc_profile) =
+            Self::decode_with_limits(image_bytes, format, config.max_src_resolution_mp)?;
+
+        // #33: autorotate (imgproxy's `auto_rotate`/`ar` option, on by
+        // default - see `ResizeQuery::autorotate`) must be applied *before*
+        // any resize/crop math below, not after: `Orientation::Rotate90`/
+        // `Rotate270` swap width and height, so `src_width`/`src_height`
+        // (read immediately below, and used for every fit/fill/force/auto
+        // decision and the #36 upscale guard) must already reflect the
+        // corrected axes. Applying it after a crop would compose the crop
+        // against the wrong axes entirely.
+        if params.autorotate {
+            img.apply_orientation(orientation);
+        }
 
         let (src_width, src_height) = img.dimensions();
 
@@ -586,13 +600,30 @@ impl ImageService {
         // already depends on, not a new dependency. JPEG now uses an
         // explicit `JpegEncoder::new_with_quality` (#35) instead of
         // `write_to`'s implicit default-quality construction, so
-        // `params.quality`/`params.jpeg_quality` actually reach the encoder.
+        // `params.quality`/`params.jpeg_quality` actually reach the encoder
+        // - and, being an explicit `JpegEncoder` rather than whatever
+        // `write_to` builds internally, it's also the only way to reach
+        // `ImageEncoder::set_icc_profile` (#33), so the same encoder value
+        // now carries both the requested quality and the forwarded colour
+        // profile.
         //
         // PNG has no quality knob in `params` to honour - `CompressionType`
         // is a fixed lossless setting, not a continuous 0-100 scale, and
         // `fq:png:N` is rejected at parse time
         // (`src/modules/url/options.rs`) rather than silently accepted and
         // ignored here.
+        //
+        // #33: `icc_profile`, if the source carried one, is forwarded to
+        // whichever of these two encoders is used - both support embedding
+        // it (`image-0.25.10/src/codecs/{png,jpeg/encoder}.rs`). WebP is
+        // the one format this can't cover: the `webp` crate (0.3.1, this
+        // service's only route to *lossy* WebP encoding - see the doc
+        // comment above) has no ICC-profile API at all, so a source colour
+        // profile is still dropped on that path. Fixing that would mean
+        // either switching WebP encoding to a crate with profile support or
+        // patching raw ICC chunks into libwebp's container format by hand -
+        // real work, not a small addition, so it's left as follow-up rather
+        // than half-done here.
         let output_bytes = match output_format {
             ImageFormat::WebP => {
                 let lossless = params.webp_lossless.unwrap_or(false);
@@ -614,11 +645,19 @@ impl ImageService {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                let encoder = image::codecs::png::PngEncoder::new_with_quality(
+                let mut encoder = image::codecs::png::PngEncoder::new_with_quality(
                     &mut buf,
                     image::codecs::png::CompressionType::Best,
                     image::codecs::png::FilterType::Adaptive,
                 );
+                if let Some(icc) = icc_profile {
+                    // `PngEncoder::set_icc_profile` only fails for
+                    // genuinely unsupported encoders, never for
+                    // `PngEncoder` itself - ignore failure rather than turn
+                    // a best-effort colour-fidelity improvement into a hard
+                    // request error.
+                    let _ = encoder.set_icc_profile(icc);
+                }
                 img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
@@ -633,7 +672,15 @@ impl ImageService {
                 let estimated_size = Self::estimate_output_size(&img, &output_format);
                 let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
 
-                let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                let mut encoder =
+                    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+                if let Some(icc) = icc_profile {
+                    // Same best-effort reasoning as the PNG branch above:
+                    // `JpegEncoder::set_icc_profile` only fails for
+                    // genuinely unsupported encoders, never for
+                    // `JpegEncoder` itself.
+                    let _ = encoder.set_icc_profile(icc);
+                }
                 img.write_with_encoder(encoder)
                     .context(format!("Failed to encode image to {:?}", output_format))?;
 
@@ -987,14 +1034,49 @@ impl ImageService {
     /// accidental 512MiB `max_alloc` default (#26). This is defense in
     /// depth behind `check_source_resolution`'s header-only check, not a
     /// replacement for it.
+    ///
+    /// Also returns the source's EXIF `Orientation` (#33) and embedded ICC
+    /// colour profile, if any - both must be read off the `ImageDecoder`
+    /// before it's consumed by `DynamicImage::from_decoder`, which is why
+    /// this goes through `ImageReader::into_decoder` rather than the
+    /// simpler `ImageReader::decode` it used to call directly.
+    /// `orientation` defaults to `Orientation::NoTransforms` (rather than
+    /// failing the whole request) if it can't be read - a source with
+    /// malformed EXIF should still decode and process, just without
+    /// autorotation.
     fn decode_with_limits(
         image_bytes: &[u8],
         format: Option<ImageFormat>,
         max_src_resolution_mp: u64,
-    ) -> Result<image::DynamicImage> {
+    ) -> Result<(image::DynamicImage, Orientation, Option<Vec<u8>>)> {
         let mut reader = Self::make_reader(image_bytes, format)?;
-        reader.limits(Self::build_decode_limits(max_src_resolution_mp));
-        reader.decode().context("Failed to decode image")
+        let limits = Self::build_decode_limits(max_src_resolution_mp);
+        reader.limits(limits.clone());
+
+        let mut decoder = reader
+            .into_decoder()
+            .context("Failed to construct image decoder")?;
+
+        // `ImageReader::decode` applies one extra allocation guard beyond
+        // `set_limits`'s dimension check: it reserves `decoder.total_bytes()`
+        // against `max_alloc` before any pixel data is decoded.
+        // `into_decoder` alone (needed here so orientation/ICC can be read
+        // off the decoder before it's consumed) skips that step, so it's
+        // replicated by hand to keep the exact same allocation guard #26
+        // relies on.
+        let mut reserved_limits = limits;
+        reserved_limits
+            .reserve(decoder.total_bytes())
+            .context("Failed to decode image")?;
+        decoder
+            .set_limits(reserved_limits)
+            .context("Failed to decode image")?;
+
+        let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+        let icc_profile = decoder.icc_profile().ok().flatten();
+
+        let img = image::DynamicImage::from_decoder(decoder).context("Failed to decode image")?;
+        Ok((img, orientation, icc_profile))
     }
 
     /// Explicit decode limits derived from the configured max source
@@ -1103,6 +1185,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         }
     }
 
@@ -2023,6 +2106,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background,
+            autorotate: true,
         }
     }
 
@@ -2378,6 +2462,169 @@ mod tests {
             out_lossy.len(),
             out_lossless.len(),
             "lossy and lossless webp encodes of the same photographic source should differ in size"
+        );
+    }
+
+    // ---- #33: EXIF autorotate ----
+
+    /// `fixtures::oriented(code)`'s marker sits in the top-left
+    /// `ORIENTED_MARKER`x`ORIENTED_MARKER` block of the *canonical*
+    /// (already-upright) image - see that fixture's doc comment. `(5, 5)`
+    /// is well inside it regardless of any JPEG-block-boundary blur from
+    /// decoding the lossy source.
+    fn assert_reddish(pixel: [u8; 3], context: &str) {
+        let [r, g, b] = pixel;
+        assert!(
+            r > 150 && i32::from(r) - i32::from(b) > 40,
+            "{context}: expected a reddish marker pixel, got {pixel:?} (r={r} g={g} b={b})"
+        );
+    }
+
+    /// Counterpart to `assert_reddish` for the canonical image's blue
+    /// background.
+    fn assert_blueish(pixel: [u8; 3], context: &str) {
+        let [r, g, b] = pixel;
+        assert!(
+            b > 150 && i32::from(b) - i32::from(r) > 40,
+            "{context}: expected a blueish background pixel, got {pixel:?} (r={r} g={g} b={b})"
+        );
+    }
+
+    /// #33: every one of the eight standard EXIF orientation values must
+    /// decode to the same upright `ORIENTED_W`x`ORIENTED_H` layout -
+    /// `fixtures::oriented`'s canonical marker (red top-left block on a
+    /// blue background) landing in the same place regardless of how the
+    /// source pixels were actually stored, dimensions included (5-8 swap
+    /// width/height in the stored file). No resize is requested here, so
+    /// this isolates autorotate itself from the resize/crop math the next
+    /// test covers.
+    #[test]
+    fn all_eight_exif_orientations_render_upright() {
+        let config = PerformanceConfig::default();
+
+        for code in 1u8..=8 {
+            let bytes = fixtures::oriented(code);
+            let params = ResizeQuery {
+                format: ApiImageFormat::Png,
+                ..query(None, None)
+            };
+
+            let (output, _content_type) =
+                ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                    .unwrap_or_else(|e| {
+                        panic!("orientation {code}: processing should succeed: {e}")
+                    });
+
+            let decoded = image::load_from_memory(&output)
+                .unwrap_or_else(|e| panic!("orientation {code}: output should decode: {e}"));
+            assert_eq!(
+                decoded.dimensions(),
+                (fixtures::ORIENTED_W, fixtures::ORIENTED_H),
+                "orientation {code}: expected the canonical upright dimensions"
+            );
+
+            let rgb = decoded.to_rgb8();
+            assert_reddish(
+                rgb.get_pixel(5, 5).0,
+                &format!("orientation {code}, marker corner"),
+            );
+            assert_blueish(
+                rgb.get_pixel(100, 70).0,
+                &format!("orientation {code}, background"),
+            );
+        }
+    }
+
+    /// #33: the order-of-operations case the issue explicitly calls out -
+    /// autorotate must be applied *before* resize, or a crop/scale composes
+    /// against the wrong axes. `fixtures::oriented(6)` is stored 90-degrees
+    /// rotated (80x120, portrait) under EXIF orientation 6; a `Fit` request
+    /// naming only a width is aspect-ratio-preserving against whatever
+    /// dimensions the resize step sees. If autorotation happened after
+    /// resize (or not at all), the resize would run against the stored
+    /// 80x120 portrait shape instead of the corrected 120x80 landscape one,
+    /// producing the wrong output dimensions and a sideways marker.
+    #[test]
+    fn rotated_source_with_resize_produces_correctly_oriented_output_at_right_dimensions() {
+        let bytes = fixtures::oriented(6); // stored 80x120, corrects to 120x80
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            format: ApiImageFormat::Png,
+            ..query(Some(60), None) // half-scale fit, preserving the corrected 3:2 aspect
+        };
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let decoded = image::load_from_memory(&output).expect("output should decode");
+        assert_eq!(
+            decoded.dimensions(),
+            (60, 40),
+            "expected the corrected (landscape) aspect ratio scaled to width 60, not the \
+             stored (portrait) shape"
+        );
+
+        let rgb = decoded.to_rgb8();
+        assert_reddish(rgb.get_pixel(3, 3).0, "resized marker corner");
+        assert_blueish(rgb.get_pixel(50, 35).0, "resized background");
+    }
+
+    /// #33: `autorotate: false` must leave the image exactly as stored -
+    /// the opt-out this crate's `ar:0` URL option (and imgproxy's own
+    /// `IMGPROXY_AUTO_ROTATE=false`) exists for. No resize is requested, so
+    /// the output dimensions must match the *stored* (portrait, un-rotated)
+    /// shape, not the corrected (landscape) one the previous two tests
+    /// assert.
+    #[test]
+    fn autorotate_disabled_leaves_image_as_stored() {
+        let bytes = fixtures::oriented(6); // stored 80x120
+        let config = PerformanceConfig::default();
+        let params = ResizeQuery {
+            autorotate: false,
+            ..query(None, None)
+        };
+
+        let (output, _content_type) =
+            ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
+                .expect("processing should succeed");
+
+        let decoded = image::load_from_memory(&output).expect("output should decode");
+        assert_eq!(
+            decoded.dimensions(),
+            (fixtures::ORIENTED_H, fixtures::ORIENTED_W),
+            "autorotate=false must leave the stored (portrait) dimensions untouched, not \
+             apply the EXIF correction"
+        );
+    }
+
+    /// #33: a source with no EXIF orientation tag at all must be completely
+    /// unaffected by `autorotate` - `fixtures::photo_like` carries no Exif
+    /// segment, so `decoder.orientation()` reports `NoTransforms` either
+    /// way and `apply_orientation` is a no-op regardless of the flag,
+    /// making output byte-for-byte identical between the two.
+    #[test]
+    fn images_without_orientation_tag_are_unaffected_by_autorotate() {
+        let bytes = fixtures::photo_like(); // 1920x1080, no Exif segment
+        let config = PerformanceConfig::default();
+
+        let with_autorotate = query_with_type(Some(300), Some(200), ResizeType::Fit);
+        let without_autorotate = ResizeQuery {
+            autorotate: false,
+            ..query_with_type(Some(300), Some(200), ResizeType::Fit)
+        };
+
+        let (output_on, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &with_autorotate, &config)
+                .expect("autorotate=true processing should succeed");
+        let (output_off, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &without_autorotate, &config)
+                .expect("autorotate=false processing should succeed");
+
+        assert_eq!(
+            output_on, output_off,
+            "a source with no EXIF orientation tag must produce identical output regardless \
+             of autorotate"
         );
     }
 }

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -1350,7 +1350,7 @@ impl ImageService {
     /// `output_width`/`output_height`) - exactly, so this prediction matches
     /// what `Decompress::scale` will actually produce.
     fn mozjpeg_scaled_dimension(dim: u32, scale_num: u8) -> u32 {
-        ((u64::from(dim) * u64::from(scale_num) + 7) / 8) as u32
+        (u64::from(dim) * u64::from(scale_num)).div_ceil(8) as u32
     }
 
     /// Runs the actual mozjpeg/libjpeg-turbo pixel decode at `scale_num/8`

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -497,6 +497,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 
@@ -574,6 +577,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         });
 

--- a/src/services/resize/handler.rs
+++ b/src/services/resize/handler.rs
@@ -501,6 +501,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         });
 
         let mut handles = Vec::with_capacity(100);
@@ -581,6 +582,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         });
 
         let mut handles = Vec::with_capacity(20);

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -468,6 +468,9 @@ mod tests {
             grayscale: None,
             enlarge: false,
             quality: None,
+            jpeg_quality: None,
+            webp_quality: None,
+            webp_lossless: None,
             background: None,
         };
         let key = cache.generate_key(&params);

--- a/src/services/storage/handler.rs
+++ b/src/services/storage/handler.rs
@@ -472,6 +472,7 @@ mod tests {
             webp_quality: None,
             webp_lossless: None,
             background: None,
+            autorotate: true,
         };
         let key = cache.generate_key(&params);
         assert!(

--- a/tests/dssim_harness.rs
+++ b/tests/dssim_harness.rs
@@ -1,0 +1,45 @@
+// TEMPORARY, throwaway harness for manual DSSIM verification of #63 stage 2
+// (mozjpeg DCT-scaled decode). Not part of the permanent test suite - dumps
+// pipeline output for a real photograph to a path named by the DSSIM_OUT env
+// var, for offline comparison with the `dssim` CLI. Delete before merging.
+use emgr::models::params::{ImageFormat as ApiImageFormat, ResizeQuery, ResizeType};
+use emgr::services::image::handler::ImageService;
+
+#[test]
+#[ignore]
+fn dump_dssim_comparison_png() {
+    let bytes = std::fs::read("bench-imgproxy/fixtures/corpus/photo_4k.jpg")
+        .expect("real photo corpus should be present at bench-imgproxy/fixtures/corpus/photo_4k.jpg");
+
+    let width: u32 = std::env::var("DSSIM_WIDTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(200);
+    let height: u32 = std::env::var("DSSIM_HEIGHT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(113);
+
+    let params = ResizeQuery {
+        url: "https://example.com/photo.jpg".to_string(),
+        width: Some(width),
+        height: Some(height),
+        resize_type: ResizeType::Fit,
+        format: ApiImageFormat::Png,
+        blur_sigma: None,
+        grayscale: None,
+        enlarge: false,
+        quality: None,
+        jpeg_quality: None,
+        webp_quality: None,
+        webp_lossless: None,
+        background: None,
+        autorotate: true,
+    };
+
+    let (bytes_out, _) = ImageService::process_image_blocking(&bytes, &params).expect("process");
+
+    let out_path = std::env::var("DSSIM_OUT").unwrap_or_else(|_| "/tmp/dssim_out.png".to_string());
+    std::fs::write(&out_path, bytes_out).expect("write output");
+    eprintln!("wrote {out_path}");
+}


### PR DESCRIPTION
## Summary

Closes **#63** (stage 2). Stacked on [#71](https://github.com/vaam-store/image-resizer/pull/71) → [#70](https://github.com/vaam-store/image-resizer/pull/70); review those first.

Decodes large JPEGs directly at 1/8, 1/4 or 1/2 scale when the requested output is much smaller, rather than decoding at full resolution and discarding most of it.

| | before | after | |
|---|---:|---:|---|
| 4K → 200x113 thumbnail | 39.67 ms | **19.27 ms** | **2.06x** |
| 1920x1080 → 300x300 | — | — | **−38.5%** |

## Against imgproxy — median of 3 valid runs

All runs verified `outcome_non2xx=0`, `outcome_timeout=0`, `outcome_conn_error=0`.

| | after stage 1 | after stage 2 |
|---|---|---|
| p90 gap | 2.19x | **1.67x** |
| throughput gap | 1.73x | **1.44x** |
| **p99 gap** | 2.22x | **2.28x — not closed** |

**The p99 result is flat and is reported as such.** The tail is evidently dominated by something other than decode. That deserves its own investigation rather than being quietly folded into a headline about p90.

## Correctness

**Never decodes below target.** Scale selection predicts post-resize dimensions by reproducing the real resize stage's branch logic read-only — fit/fill/force/auto, the #36 upscale guard, `resize_dimensions` — then picks the most aggressive libjpeg scale still `>=` that target on both axes. EXIF orientation is accounted for: Rotate90/270 swaps the axes, so the target is mapped into raw pre-rotation space first.

**Full-scale requests skip mozjpeg entirely.** This is a correctness requirement, not an optimisation. mozjpeg's IDCT and chroma upsampling differ slightly from zune-jpeg's, and routing every JPEG through it broke `webp_lossless_round_trips_byte_identical_pixels`. Non-downscaling requests are now byte-identical to before.

**All four guards preserved** on the new path: the #26 resolution check, the manual `limits.reserve` allocation guard, #33's orientation/ICC extraction, and a fallback to the `image` crate on any mozjpeg error. mozjpeg's error manager *unwinds* rather than returning `Err`, so the libjpeg call is additionally wrapped in `catch_unwind` — verified with garbage input.

## Quality — DSSIM vs full decode, real 4K photograph

| scale | target | DSSIM |
|---|---|---|
| 1/8 | 200x113 | 0.0000673 |
| 1/4 | 700x400 | 0.0002060 |
| 1/2 | 1800x1000 | 0.0010909 |

All below just-noticeable-difference (~0.001–0.01), and attributable to IDCT rounding rather than lost information — confirmed by the full-scale path being byte-identical.

## Also in here

`bench-imgproxy/driver/run.sh` brought up **every** engine regardless of `$ENGINES`, so a two-engine run still built `emgr_s3` and any unrelated failure there aborted the sweep before a single request was sent. Now it builds only what is being measured.

## Note for reviewers hitting a build failure

The Dockerfile uses a cargo target cache mount. A stale cache from before the bookworm builder pin (#62) will fail to **link** `aws_lc_sys` with `undefined reference to __isoc23_sscanf` — the same glibc symbol family as #62, but at link time rather than runtime. It is a **cache artifact, not a regression**:

```
docker builder prune --filter type=exec.cachemount
```

This has now produced a convincing false alarm twice.

## Verification

- `cargo check --features local_fs --bins --tests --benches` — 0 errors
- `cargo check --features s3` — 0 errors
- `cargo test --features local_fs` — **440 passed**
- `cargo test --features s3` — **430 passed**
- s3 image rebuilt after cache prune: builds and starts

## Reviewer focus

1. **`select_jpeg_dct_scale`** — the "never below target" property is what protects quality; there is a property test, but the axis-swap interaction with EXIF is the subtle part.
2. **The four preserved guards** — a perf change silently undoing a security fix is the failure mode worth checking for.
3. **The flat p99** — worth agreeing it is a separate problem rather than a shortfall of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
