### PR TITLE
fix(bench): measure per-image latency, not per-request

### DIFF
--- a/.bench-baseline/BASELINE.md
+++ b/.bench-baseline/BASELINE.md
@@ -125,3 +125,132 @@ photo (NASA `nasa-4928x3279.png`) and the `alpha_fringe_rgba` fixture:
 385/385 tests pass (`cargo test --features local_fs`, unchanged count).
 `cargo check --features local_fs --bins --tests --benches` and
 `cargo check --features s3` both 0 errors.
+
+## Post-wave-2 baseline — `main` @ `41aee92` (2026-08-21)
+
+**Provenance:** merged `main` at commit `41aee92`, which includes wave 2
+(#49 AVIF, #50 animation, #51 gravity, #52 geometry/watermarks/presets) on
+top of everything in the "Current baseline" section above, plus #63 stage 2
+(DCT-scaled JPEG decode via mozjpeg). Command:
+`cargo bench --features local_fs -- --sample-size 20 --measurement-time 2 --warm-up-time 1`.
+Profile: criterion default (release). Machine: darwin/arm64. All figures are
+medians.
+
+| Bench | Median | Note |
+|---|---:|---|
+| cache_key/generate_key | 1.70 µs | was 954 ns at #63 stage 1 — wave 2 roughly doubled the number of fields hashed into the cache key (gravity/geometry/watermark/preset params) |
+| decode/jpeg 1920x1080 | 9.01 ms | |
+| decode/png 1920x1080 | 14.36 ms | |
+| decode/webp 1920x1080 | 25.32 ms | |
+| encode/jpeg | 3.07 ms | |
+| encode/png | 1.70 ms | |
+| encode/webp | 23.79 ms | see "encode/webp trap" below — this is NOT a 10x regression |
+| resize_fir/downscale lanczos3 | 3.47 ms | |
+| resize_fir/downscale triangle | 1.17 ms | |
+| pipeline photo_like → thumbnail_jpg | 6.32 ms | was 10.78 ms at #63 stage 1 — the 41% gain is #63 stage 2's DCT-scaled decode |
+| pipeline flat → resize_png | 8.58 ms | |
+| pipeline alpha → resize_webp | 5.41 ms | |
+| pipeline photo_4k → large_downscale_thumbnail_jpg | 19.61 ms | new bench, added by #63 stage 2 |
+
+### `encode/webp` trap: a third instance of the same pattern this file already warns about twice
+
+`encode/webp` reads 23.79 ms here against 2.25 ms in the oldest table at the
+top of this file, and 2.94 ms in the `pipeline alpha -> resize webp` line
+from the same era. Read naively that looks like a ~10x regression. **It is
+not.** The old number was produced by the `image` crate's lossless-only
+WebP encoder — cheap, because lossless WebP on synthetic/noise-heavy input
+does comparatively little work. #32/#60 replaced that path with real lossy
+libwebp via `ImageService::encode_webp` (the `webp` crate, same underlying
+encoder imgproxy uses); `benches/encode.rs` calls `ImageService::encode_webp`
+directly, so this bench has been measuring the lossy encoder since #32/#60
+landed, not the encoder that produced the 2.25 ms/2.94 ms numbers. It does
+far more work (real rate-distortion search) for a much smaller output file.
+This is the same class of trap as the `decode/jpeg` `zune-jpeg` version-bump
+note and the `pipeline alpha -> resize webp` note already on this file — an
+apparent regression that is actually a different, more capable code path
+being measured, not a performance loss in the same code.
+
+### Wave 2 cost on the hot path: unmeasurable
+
+Wave 2 (#49/#50/#51/#52 — AVIF, animation, gravity, geometry/watermarks/
+presets) added nothing measurable to the request path that doesn't opt into
+those features. The end-to-end harness's cold-cache per-request numbers
+(see `bench-imgproxy/README.md`'s validated section) before wave 2 —
+21.25 / 107.06 / 297.56 ms p50/p90/p99 — and after wave 2 — 22.87 / 104.63 /
+296.49 ms, same metric, same harness — are identical within noise. This is
+expected: every wave-2 feature is opt-in per request (a request that doesn't
+ask for AVIF, animation, gravity, geometry ops, a watermark, or a preset
+does not pay for parsing or applying one), and `cache_key/generate_key`'s
+own move from 954 ns to 1.70 µs is itself negligible against a
+multi-millisecond pipeline.
+
+### End-to-end (imgproxy vs. emgr, three engines): see `bench-imgproxy/README.md`
+
+The criterion numbers above are single-operation micro-benchmarks within
+the Rust binary. The full end-to-end comparison against imgproxy — request
+routing, source fetch, storage round trip, and (for emgr) the redirect hop
+— lives in `bench-imgproxy/README.md`'s "Validated" section, captured on
+this same commit (`41aee92`). Two things changed there since the last time
+this file was updated, both from fixing a measurement bug rather than from
+any code change:
+
+1. **The metric being reported was wrong, not just the numbers.**
+   `http_req_duration` (per-HTTP-request) and the `throughput_rps` derived
+   from it are not comparable across engines that issue a different number
+   of HTTP requests per delivered image — emgr answers with a 301 redirect
+   to storage that k6 follows, so one delivered image costs emgr ~2.00 HTTP
+   requests (`http_reqs_per_iteration`) against imgproxy's 1.00. Blending
+   emgr's near-instant redirects (~0.13 ms) with its real transforms into
+   one per-request distribution drags the reported median down, making
+   emgr's cold-cache p50 look "at parity" with imgproxy (22.87 vs 20.66 ms)
+   when it was not. The corrected, comparable metric is `iteration_duration`
+   (true wall-clock per delivered image, redirect hops included) and
+   `images_per_second` — see `bench-imgproxy/driver/k6-script.js`'s
+   `handleSummary` for both the metric definitions and the in-code comment
+   explaining the trap.
+2. **The true gap is substantially larger than what was previously
+   reported.** Cold cache, per delivered image, medians of 3 runs, 2 VUs,
+   30s, 36 fixture combos, every run verified `outcome_non2xx = 0` /
+   `outcome_timeout = 0` / `outcome_conn_error = 0`:
+
+   | engine | p50 ms | p90 ms | p99 ms | images/s | req/image |
+   |---|---:|---:|---:|---:|---:|
+   | imgproxy | 20.76 | 65.60 | 136.04 | 62.85 | 1.00 |
+   | emgr local_fs | 75.81 | 154.02 | 306.04 | 21.72 | 2.00 |
+   | emgr s3 | 73.81 | 160.67 | 313.81 | 21.97 | 2.00 |
+
+   emgr local_fs vs. imgproxy: p50 3.65x slower, p90 2.35x, p99 2.25x,
+   throughput 2.89x lower. emgr s3: p50 3.56x, p90 2.45x, p99 2.31x,
+   throughput 2.86x lower. For contrast, the old (misleading, per-request)
+   view of the same runs: imgproxy p50 20.66 / p90 65.51 / p99 135.87; emgr
+   p50 22.87 / p90 104.63 / p99 296.49; emgr_s3 p50 21.83 / p90 106.72 / p99
+   301.98 — the number that previously read as "near parity" (22.87 vs
+   20.66) was an artifact of the redirect-blended distribution, not a real
+   result.
+
+   emgr's 75.81 ms cold p50 is also not 75.81 ms of image processing — it is
+   process → write to storage → 301 → client re-fetches from storage. Part
+   of that figure is the two-round-trip delivery architecture itself, which
+   is the same architecture that makes emgr's warm-cache path so cheap (see
+   below and `bench-imgproxy/README.md`'s "Three engines, one asymmetry").
+
+   Warm cache, per delivered image, same run set:
+
+   | engine | p50 ms | p90 ms | p99 ms | images/s |
+   |---|---:|---:|---:|---:|
+   | imgproxy | 21.08 | 65.46 | 132.92 | 62.91 |
+   | emgr local_fs | 0.40 | 0.53 | 0.92 | 4688.13 |
+   | emgr s3 | 0.62 | 0.88 | 1.62 | 2872.05 |
+
+   Warm delivers real image bytes (verified: emgr average response 117,642 B
+   vs imgproxy 118,858 B, median 16,128 vs 9,405, max ~1.2 MB both — not
+   empty redirects, not 304s), but **this is not a processing-speed
+   comparison and must not be read as one.** imgproxy has no result cache
+   and reprocesses every request; emgr short-circuits a repeat request to a
+   301 at its storage backend before ever touching the image pipeline. In
+   production, imgproxy normally sits behind a CDN that would absorb repeat
+   requests, so the honest framing of the warm numbers is "emgr's built-in
+   result cache vs. imgproxy's reliance on an external one" — a genuine and
+   important architectural advantage for emgr, but not evidence that emgr
+   processes images faster. **The cold numbers above are the processing
+   comparison, and emgr loses those 3.65x (local_fs) / 3.56x (s3).**

--- a/bench-imgproxy/README.md
+++ b/bench-imgproxy/README.md
@@ -302,6 +302,45 @@ older runs of this harness had; numbers from before #57 landed were
 produced under the loopback-vs-bridge split described above and are not
 directly comparable on that dimension.
 
+## Which metric to trust
+
+Each `results/*.json` report (`driver/k6-script.js`'s `handleSummary`)
+exports two views of latency and throughput, and they are **not**
+interchangeable:
+
+| Metric | What it measures | Comparable across engines? |
+|---|---|---|
+| `http_req_duration` | latency of a single HTTP request | **No** |
+| `throughput_rps` (from `http_reqs.rate`) | HTTP requests/sec | **No** |
+| `iteration_duration` | wall-clock for one complete delivered image, redirect hops included | **Yes** |
+| `images_per_second` (from `iterations.rate`) | delivered images/sec | **Yes** |
+| `http_reqs_per_iteration` | HTTP requests issued per delivered image | the tell, see below |
+
+The reason: `emgr` and `emgr_s3` answer a resize request with a `301`
+redirect to wherever the derivative is stored, and k6 follows it, so
+delivering **one** image costs emgr two HTTP requests (`http_reqs_per_iteration`
+reads `2.00` for both emgr flavours). `imgproxy` streams the transformed
+bytes back on the original request, so it costs `1.00`. `http_req_duration`
+and the `throughput_rps` derived from `http_reqs.rate` are per-*request*
+metrics, so they silently compare "the average of a near-instant 301 and a
+real transform" (emgr) against "a real transform" (imgproxy) — that mixture
+drags emgr's reported median down and roughly doubles emgr's apparent
+`throughput_rps`, in a way that has nothing to do with which engine
+processes images faster. This produced a real, previously-reported error:
+emgr's cold-cache p50 read as "at parity" with imgproxy (22.87 vs 20.66 ms,
+per-request) when the true per-delivered-image figure is 75.81 vs 20.76 ms
+— 3.65x slower, not parity. See `.bench-baseline/BASELINE.md`'s 2026-08-21
+section for the full before/after comparison on real data.
+
+**Always read `iteration_duration` and `images_per_second` when comparing
+engines.** `http_req_duration` and `throughput_rps` are kept in the report
+for continuity with earlier runs and for tracking a single engine's own
+trend over time (where the per-engine request-count ratio is constant), not
+for cross-engine comparison. Check `http_reqs_per_iteration` first whenever
+you're unsure which metrics in a given report are safe to compare — `1.00`
+means per-request and per-image are the same thing for that engine, `2.00`
+means they are not.
+
 ## Scenarios
 
 Run via `driver/run.sh`, which sweeps `ENGINES x SCENARIOS x CONCURRENCIES`.
@@ -445,9 +484,12 @@ convention):
 
 ## Status of this harness as delivered
 
-**`imgproxy` and `emgr` (local_fs) are validated end-to-end with real
-numbers below. `emgr_s3` is blocked by a pre-existing bug outside this
-harness's scope -- see "Known blocker" below.**
+**All three engines -- `imgproxy`, `emgr` (local_fs), and `emgr_s3` -- are
+validated end-to-end with real numbers below.** `emgr_s3` was blocked for a
+time by a pre-existing bug outside this harness's scope; that bug is now
+fixed -- see "Resolved: `emgr_s3` GLIBC_2.38 startup crash" below for the
+root cause and the fix, and `.bench-baseline/BASELINE.md`'s 2026-08-21
+section for the s3 numbers this unblocked.
 
 ### Validated: imgproxy vs. emgr (local_fs), cold cache, concurrency 2
 
@@ -481,52 +523,55 @@ this is *not yet* the number that isolates image-processing speed from
 storage-serving cost. That isolation is exactly what the `emgr_s3` leg
 below was meant to provide.
 
-### Known blocker: `emgr_s3` cannot start -- `s3_deploy` build is broken independent of this harness
+### Resolved: `emgr_s3` GLIBC_2.38 startup crash
 
-`compose.yaml`, `driver/run.sh` and `driver/k6-script.js` are fully wired
-for the three-way comparison (`docker compose config` validates cleanly,
-`origin`/`minio`/`minio_init`/`imgproxy`/`emgr` all reach `healthy` and the
-bucket is created and made public correctly). `emgr_s3` builds successfully
-but its container **crashes on startup**:
+`compose.yaml`, `driver/run.sh` and `driver/k6-script.js` were fully wired
+for the three-way comparison from the start (`docker compose config`
+validates cleanly, `origin`/`minio`/`minio_init`/`imgproxy`/`emgr` all
+reached `healthy` and the bucket was created and made public correctly),
+but for a time `emgr_s3` built successfully and then **crashed on
+startup**:
 
 ```
 /app/emgr: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/emgr)
 ```
 
-This is a **pre-existing bug in the repo root `Dockerfile`**, not something
-introduced by this harness, and not something this harness's `bench-imgproxy/`
-scope can fix (the fix belongs in `Dockerfile`, which was explicitly out of
-scope for this work). Root cause, confirmed by diffing the two binaries
-with `objdump -T`:
+This was a **pre-existing bug in the repo root `Dockerfile`**, not
+something introduced by this harness, and not something this harness's
+`bench-imgproxy/` scope could fix on its own (the fix belonged in
+`Dockerfile`). Root cause, confirmed by diffing the two binaries with
+`objdump -T`:
 
-- The `builder` stage (`FROM rust@sha256:...`) is Debian 13 "trixie"
+- The `builder` stage (`FROM rust@sha256:...`) was Debian 13 "trixie"
   (glibc 2.41). `base_deploy` (`FROM gcr.io/distroless/cc-debian12@sha256:...`)
   is Debian 12 "bookworm" (glibc ~2.36) -- a **major Debian version
   mismatch between the compile stage and the runtime stage**.
-- Only the `s3`-feature binary references `GLIBC_2.38` symbols
+- Only the `s3`-feature binary referenced `GLIBC_2.38` symbols
   (`__isoc23_sscanf`, `__isoc23_strtol` -- ISO C23 `sscanf`/`strtol`
   variants that Debian 13's newer glibc headers alias to by default). The
-  `local_fs`-feature binary (`emgr`, confirmed working above) references no
-  symbol newer than `GLIBC_2.34`. This points at the `s3` feature's native
-  C dependency chain (almost certainly `aws-lc-sys`, the only C code the
-  `s3` feature compiles) picking up the builder's newer glibc headers at
-  compile time, in a way `local_fs`'s pure-Rust dependency tree never does.
+  `local_fs`-feature binary (`emgr`) referenced no symbol newer than
+  `GLIBC_2.34`. This pointed at the `s3` feature's native C dependency
+  chain (almost certainly `aws-lc-sys`, the only C code the `s3` feature
+  compiles) picking up the builder's newer glibc headers at compile time,
+  in a way `local_fs`'s pure-Rust dependency tree never does.
 - `base_deploy`'s glibc (Debian 12) predates `GLIBC_2.38` entirely, so the
-  binary fails to even start, regardless of runtime configuration -- this
-  is not fixable from `compose.yaml` (no env var, build arg, or Cargo
-  feature flag changes which glibc headers the builder's C toolchain links
-  against).
-- The fix belongs in `Dockerfile`: either bump `base_deploy` to a
-  Debian-13-based distroless image (e.g. `gcr.io/distroless/cc-debian13`,
-  once available) so it matches the builder stage, or pin the `builder`
-  stage to a Debian-12-based Rust image so it matches `base_deploy`. Either
-  change needs to preserve identical `local_fs` behavior, since that build
-  is already working.
+  binary failed to even start, regardless of runtime configuration -- not
+  fixable from `compose.yaml` (no env var, build arg, or Cargo feature flag
+  changes which glibc headers the builder's C toolchain links against).
 
-Once that lands, `emgr_s3` needs no changes on this harness's side to run
--- `compose.yaml`, `driver/run.sh`'s healthcheck loop (`emgr:18081`,
-`emgr_s3:18087`), and `driver/k6-script.js`'s `urlBuilders.emgr_s3` are
-already in place and were validated up to exactly this point (build
-succeeds, `origin`/`minio`/`minio_init` all become healthy with `emgr_s3`
-correctly waiting on all three via `depends_on`, and the only failure is
-the container's own entrypoint refusing to start).
+**The fix:** the `builder` stage in `Dockerfile` was pinned to a
+Debian-12-based ("bookworm") Rust image, so it now matches `base_deploy`'s
+Debian 12 distroless runtime instead of drifting ahead of it on Debian 13.
+That removes the version mismatch at its source -- both stages now link
+against and ship the same glibc generation -- while leaving `local_fs`
+behavior unchanged (it never depended on the newer glibc symbols in the
+first place).
+
+`emgr_s3` now builds and runs correctly with no changes needed on this
+harness's side -- `compose.yaml`, `driver/run.sh`'s healthcheck loop
+(`emgr:18081`, `emgr_s3:18087`), and `driver/k6-script.js`'s
+`urlBuilders.emgr_s3` were already in place and are now validated
+end-to-end: `emgr_s3` builds, starts, becomes healthy, and served every
+request in the measurement runs recorded in `.bench-baseline/BASELINE.md`'s
+2026-08-21 section (both cold and warm cache, zero non-2xx/timeout/
+connection errors).

--- a/bench-imgproxy/driver/k6-script.js
+++ b/bench-imgproxy/driver/k6-script.js
@@ -272,7 +272,32 @@ export function handleSummary(data) {
         ? data.metrics.outcome_conn_error.values.count
         : 0,
       iterations: data.metrics.iterations ? data.metrics.iterations.values.count : 0,
+      // NOTE: `http_reqs.rate` counts every HTTP request, and the engines do
+      // NOT issue the same number of them per delivered image. emgr answers
+      // with a 301 to storage and k6 follows it, so one delivered image costs
+      // emgr ~2 requests; imgproxy streams the bytes from the same request, so
+      // it costs 1. Comparing this number between engines therefore flatters
+      // emgr by roughly 2x. Use `images_per_second` below for the throughput
+      // comparison; this stays for continuity with earlier runs and for
+      // per-engine trend tracking, where the request-count ratio is constant.
       throughput_rps: data.metrics.http_reqs ? data.metrics.http_reqs.values.rate : null,
+      http_reqs_per_iteration:
+        data.metrics.http_reqs && data.metrics.iterations && data.metrics.iterations.values.count
+          ? data.metrics.http_reqs.values.count / data.metrics.iterations.values.count
+          : null,
+      // The honest cross-engine throughput number: completed image deliveries
+      // per second, independent of how many HTTP round trips each engine takes
+      // to deliver one.
+      images_per_second: data.metrics.iterations ? data.metrics.iterations.values.rate : null,
+      // The honest cross-engine latency number: wall-clock for one complete
+      // image delivery, redirect hops included. `http_req_duration` is
+      // per-request, so for emgr it blends near-instant 301s (min ~0.1ms) with
+      // real transforms into one bimodal distribution - which drags its median
+      // down and makes a p50 "at parity" with imgproxy an artefact of the
+      // mixture rather than a statement about processing speed.
+      iteration_duration: data.metrics.iteration_duration
+        ? data.metrics.iteration_duration.values
+        : null,
     },
   };
 


### PR DESCRIPTION
## Summary

The three-way benchmark harness was reporting two metrics that are not comparable between these engines, and the headline numbers it produced — including ones recorded in `.bench-baseline/BASELINE.md` and quoted when assessing progress against #53 — were wrong. This fixes the harness, re-measures on merged `main` (`41aee92`, post wave 2), and records both scenarios.

Source of truth: #20 (benchmark gate / harness), #53 (imgproxy parity).

## Intent

emgr answers with a `301` to storage and k6 follows it, so **one delivered image costs emgr ~2.00 HTTP requests; imgproxy streams the bytes on the original request, costing 1.00.** Every per-request metric is therefore skewed in emgr's favour:

| Metric | Reported | Actual |
|---|---:|---:|
| cold p50 | 22.87 ms vs 20.66 ms — "parity" | **75.81 ms vs 20.76 ms — 3.65×** |
| cold throughput gap | 1.44× | **2.89×** |

`http_req_duration` pooled emgr's near-instant `301`s (min ~0.13 ms) together with its real transforms into one bimodal distribution, halving the apparent median. `throughput_rps` counted the redirect as a second request.

## Scope

`handleSummary` now also exports:

- **`iteration_duration`** — wall-clock for one complete delivered image, redirect hops included. The correct cross-engine latency metric.
- **`images_per_second`** — delivered images/sec, independent of round trips per image.
- **`http_reqs_per_iteration`** — the tell that the other two were untrustworthy (2.00 vs 1.00).

The old per-request metrics stay, for continuity with earlier runs and for per-engine trend tracking where the request-count ratio is constant — with an in-place comment saying why they must not be compared across engines.

## Verification

Medians of 3 runs per engine per scenario, 2 VUs, 30 s, 36 fixture combos, on merged `main` (`41aee92`). **Every one of the 18 runs verified `outcome_non2xx = 0`, `outcome_timeout = 0`, `outcome_conn_error = 0`.**

**Cold cache — per delivered image**

| Engine | p50 | p90 | p99 | images/s | req/image |
|---|---:|---:|---:|---:|---:|
| imgproxy | 20.76 | 65.60 | 136.04 | 62.85 | 1.00 |
| emgr local_fs | 75.81 | 154.02 | 306.04 | 21.72 | 2.00 |
| emgr s3 | 73.81 | 160.67 | 313.81 | 21.97 | 2.00 |

**Warm cache — per delivered image**

| Engine | p50 | p90 | p99 | images/s |
|---|---:|---:|---:|---:|
| imgproxy | 21.08 | 65.46 | 132.92 | 62.91 |
| emgr local_fs | 0.40 | 0.53 | 0.92 | 4688.13 |
| emgr s3 | 0.62 | 0.88 | 1.62 | 2872.05 |

**Control:** imgproxy reproduced across two separate sessions almost exactly — 20.91/62.45/132.35 previously, 20.76/65.60/136.04 now. The environment did not drift, so cross-session comparison is sound.

**The warm result is not a processing-speed comparison** and is recorded with that caveat attached. imgproxy has no result cache and reprocesses every request; emgr short-circuits a repeat to a `301`. In production imgproxy normally sits behind a CDN absorbing exactly these repeats, so this is emgr's built-in result cache versus reliance on an external one. Warm delivers real bytes — emgr averages **117,642** per response against imgproxy's **118,858**, matching medians and a matching ~1.2 MB max, so these are full images rather than 304s or bare redirects.

## Risk Assessment

- **The cold gap is the processing comparison, and emgr loses it 3.65×.** Prior reporting understated this by roughly 2× across p50, p90 and throughput. Only p99 was close to right, because by the 99th percentile the fast-redirect half of the distribution has been passed.
- emgr's 75.81 ms cold is **not** 75.81 ms of image processing — it is process → write to storage → `301` → client re-fetches. Part of the gap is the two-round-trip delivery architecture, which is the same mechanism that makes the warm path cost 0.40 ms. The cold cost and the warm win cannot be separated.
- Which of the two scenarios dominates depends on production cache-miss rate, which neither benchmark measures. That number decides whether #30/#37 are urgent or near-irrelevant.
- No source code changes; harness and documentation only.

## Reviewer Focus

1. `handleSummary` in `bench-imgproxy/driver/k6-script.js` — whether `iteration_duration` is genuinely the right cross-engine metric, and whether keeping the old ones is the right call.
2. The warm-cache framing in both docs — it is the number most likely to be quoted out of context.
3. `bench-imgproxy/README.md`'s "Resolved: `emgr_s3` GLIBC_2.38 startup crash" — previously documented as an open blocker; fixed by pinning the builder to bookworm, and emgr_s3 produced every s3 figure above.

## AI Usage Declaration

AI (Claude Opus 5, orchestrating a Sonnet sub-agent for the documentation edits) found the metric flaw, fixed the harness, ran the measurements, and drafted the docs. Every figure in this description was produced by a run whose error counters were checked individually before the run was included; one run's JSON failed to write and was recovered from its log summary and validated before use. The documentation numbers were cross-checked against the measured set to confirm none were invented.

- [x] A human is accountable for this change.
- [x] Numbers come from verified runs, not model claims.
- [x] Known limitations — the warm-cache asymmetry, and the unmeasured cache-miss rate — are stated rather than omitted.
