### PR TITLE
docs: write the missing ADR 0004 (AVIF measurement)

### DIFF
--- a/adr/0004-avif-measurement.md
+++ b/adr/0004-avif-measurement.md
@@ -1,291 +1,298 @@
-# ADR 0004: AVIF vs. JPEG/WebP byte-size and encode-cost, measured on real photos at matched perceptual quality
+# ADR 0004: AVIF vs. JPEG/WebP byte-size and encode-time, measured on real photos at matched perceptual quality
 
-- Status: **Informational** — fills in a measurement that three code comments in
-  `src/services/image/handler.rs` (lines 59, 65, 827) already cited as
-  `adr/0004-avif-measurement.md`. That file never existed: `git log --all
-  --diff-filter=A -- 'adr/0004*'` returns nothing, and `git ls-tree origin/main adr/`
-  lists only 0001-0003. A prior wave-2 agent claimed to have written it but never
-  committed it — only a throwaway scratch crate and its raw output survived in a
-  session scratchpad. This ADR re-derives the numbers from that scratch crate,
-  independently re-running it to confirm reproducibility, and writes them down
-  properly.
+- Status: **Informational** — first real measurement of AVIF against JPEG and WebP for this
+  project on `origin/main` (only ADRs 0001-0003 exist there: `git ls-tree origin/main adr/`).
+  ADR 0001's original AVIF numbers (0.79x at q75, 0.42x at q50) were produced by the same flawed
+  method (synthetic fixture, unmatched nominal quality) that ADR 0003 already showed gives the
+  wrong answer for WebP; ADR 0003 explicitly left AVIF unresolved ("Open question this ADR does
+  not resolve"). This ADR closes that question using the same corrected method ADR 0003
+  established. **Supersedes an earlier draft of this same file, commit `a4788e4` on this local
+  branch (`docs/adr-0004-avif`), never merged to `origin/main`** — that draft was itself written
+  by an earlier session re-deriving numbers from a *different* prior session's already-run scratch
+  crate rather than an independent fresh run. This version discards that lineage entirely: new
+  Kodak corpus download, freshly authored harness (see Method), independently re-run end to end,
+  per this session's own instructions not to trust or reproduce any prior result blindly. The two
+  drafts' numbers end up close (0.7241 vs. 0.7347 avif/jpeg; 0.8753 vs. 0.8733 avif/webp; 367.8 ms
+  vs. ~333 ms median encode) — consistent with real run-to-run measurement noise, not a discrepancy
+  worth chasing further.
 - Date: 2026-08-21
 
 ## Context
 
-`adr/0001-image-engine.md` measured AVIF at 0.42x-0.79x a source JPEG using the same
-flawed method `adr/0003-webp-measurement.md` later retracted for WebP: a synthetic
-`gradient_noise_rgb` fixture (smooth gradient + i.i.d. per-pixel noise, which compresses
-toward the same incompressible floor regardless of which codec is actually better on
-real photographic content) compared at unmatched nominal quality numerals (JPEG q75 vs.
-AVIF q75 is not an equal-quality comparison — the two encoders' quality scales are not
-calibrated against each other). `adr/0003` fixed both flaws for the WebP question and
-found the real WebP number (0.84x, ~16% smaller) was between the original's wrong 0.96x
-and the owner's recalled 25-35% industry figure — but explicitly left AVIF unmeasured
-("Open question this ADR does not resolve"). This project has now had to correct a
-format-size claim twice for exactly this pair of methodological errors; a third
-undocumented number is not acceptable, especially since three code comments already
-assert it exists.
+`src/services/image/handler.rs` carries three comments (`DEFAULT_AVIF_QUALITY`'s doc comment,
+`DEFAULT_AVIF_SPEED`'s doc comment, and the `ImageFormat::Avif` encode arm) that cite
+`adr/0004-avif-measurement.md`. Going into this measurement, three specific figures had been
+informally cited as the expected result: AVIF vs. JPEG **0.73x** (27% smaller), AVIF vs. WebP
+**0.87x**, and AVIF encode time **~335 ms** vs. JPEG's **~4.2 ms**. All three were treated as
+unverified going in — ADR 0003 retracted an early WebP number (0.96x, no benefit at all) and ADR
+0001's own AVIF figures (0.79x/0.42x) were never re-checked, so an informally-cited number gets no
+benefit of the doubt here either, regardless of what an earlier session on this same branch
+already concluded.
+
+Same two failure modes ADR 0003 diagnosed for WebP apply identically to AVIF and are why they're
+avoided again here:
+
+1. **Synthetic fixtures compress unrealistically.** `benches/fixtures.rs`'s `gradient_noise_rgb`
+   (smooth gradient + i.i.d. per-pixel noise) is close to incompressible high-frequency noise,
+   which flattens the size gap between codecs toward the noise floor regardless of which codec
+   actually handles real photographic structure better.
+2. **Comparing nominal quality numbers across encoders is meaningless.** AVIF's `q` (via `ravif`),
+   JPEG's `q` (via `image`'s built-in encoder) and WebP's `q` (via `libwebp`) are three different,
+   uncalibrated 0-100 scales. Comparing AVIF q80 against JPEG q75 because those are each project's
+   *default* says nothing about equal perceptual quality.
+
+`bench-imgproxy/fixtures/generate.py` was checked before use and rejected for exactly reason 1:
+despite files named `photo_4k.jpg`/`photo_1080p.jpg`/`photo_800x600.jpg`, its `main()` builds all
+three via `gradient_noise_rgb(w, h, f"photo_{w}x{h}")` — the same synthetic gradient-plus-noise
+generator, not real photographs. Using it here would reproduce ADR 0001's mistake under a
+misleadingly photographic-sounding filename.
 
 ## Method
 
-Identical to `adr/0003`'s, for direct comparability: DSSIM-matched perceptual quality on
-the Kodak True Color corpus, not synthetic fixtures and not equal nominal-quality
-numerals. One change from `adr/0003`: encoders are called exactly as
-`ImageService::encode_single_image` calls them in
-`src/services/image/handler.rs` (`JpegEncoder::new_with_quality`,
-`AvifEncoder::new_with_speed_quality` with production's `DEFAULT_AVIF_SPEED = 4`, and
-`webp::Encoder::from_rgb(...).encode(quality)`, matching `adr/0003`'s own WebP call —
-production's `Self::encode_webp` uses `from_rgba` instead, see "Caveats" below), so the
-numbers describe what `emgr` itself produces, not a reference encoder.
-
 ### Scratch crate
 
-`avif-truth`, a standalone crate (own `[workspace]` table, `emgr`'s `Cargo.toml`/
-`Cargo.lock` untouched) under
-`/private/tmp/.../scratchpad/avif-truth` — this is the crate the prior wave-2 agent
-left behind; verified by reading its source, rebuilding it fresh
-(`cargo build --release`, clean compile), and re-running it independently rather than
-trusting its pre-existing output blindly. Resolved dependency versions (`rustc 1.95.0`,
-`cargo 1.95.0`):
+`avif-truth`, a standalone crate under
+`/private/tmp/.../scratchpad/avif-truth` (its own `[workspace]` table, `emgr`'s own `Cargo.toml`/
+`Cargo.lock` untouched, never committed). Unlike ADR 0003's `webp-truth` (which depended on the
+`image`/`webp` crates directly and re-implemented the encode calls), this crate depends on `emgr`
+itself as a **path dependency**, so it calls the exact code `emgr` ships rather than a
+reimplementation that could silently drift from it:
+
+- WebP: `emgr::services::image::handler::ImageService::encode_webp` — called directly, since it's
+  already `pub` for exactly this purpose (see its own doc comment: "`pub`... so `benches/encode.rs`
+  can benchmark the exact lossy path production uses").
+- JPEG and AVIF: `handler.rs`'s encode match arms build `JpegEncoder::new_with_quality` and
+  `AvifEncoder::new_with_speed_quality(buf, DEFAULT_AVIF_SPEED, quality)` inline (no `pub fn`
+  wrapper exists for either, unlike WebP) — this harness issues the identical calls, importing
+  `emgr`'s own `DEFAULT_AVIF_SPEED` constant so the speed setting can never drift from what
+  production actually uses.
+
+Resolved dependency versions, from `cargo build --release` (`rustc 1.95.0`, `cargo 1.95.0`):
 
 | Crate | Requested | Resolved | Note |
 |---|---|---|---|
-| `image` | `0.25` (`features = ["jpeg","png","webp","avif","avif-native"]`) | `0.25.10` | identical to `emgr`'s own `Cargo.lock` — same `AvifEncoder`, backed by `ravif 0.13.0`/`rav1e 0.8.1` |
+| `emgr` | path dependency | 0.1.2 | this repo, at the commit this ADR was written against |
+| `image` | `0.25` (`features = ["jpeg","png","webp","avif","avif-native","gif"]`) | `0.25.10` | same as `emgr`'s `Cargo.lock`; `avif-native` is **extra** here (decode-only, see below) |
+| `ravif` | (transitive, via `image`'s `avif` feature) | `0.13.0` | same as `emgr`'s `Cargo.lock` — the actual AVIF encoder |
 | `webp` | `0.3` | `0.3.1` | identical to `emgr`'s own `webp = "0.3"` dependency |
-| `dssim` | `3` | `3.4.0` | perceptual metric, same as `adr/0003` |
-| `rgb` | `0.8` | `0.8.53` | pixel-buffer adapter, same as `adr/0003` |
+| `dssim` | `3` | `3.4.0` | perceptual metric, same as ADR 0003 |
+| `rgb` | `0.8` | `0.8.53` | pixel-buffer adapter, same as ADR 0003 |
+| `dav1d` / `dav1d-sys` | (transitive, via `image`'s `avif-native` feature) | `0.11.1` / `0.8.3` | **decode-only** — see below |
 
-Same AGPL-3.0 caveat as `adr/0003`: `dssim` is fine for a local, throwaway,
-never-redistributed measurement tool and is **not** proposed as an `emgr` dependency.
+`emgr`'s own `image` dependency only enables the `avif` feature (encode via `ravif`), not
+`avif-native` (decode via `dav1d`) — `emgr` never decodes AVIF, only produces it, so it has no
+reason to carry a `dav1d` dependency. This harness needs to *decode* its own AVIF output back to
+RGB to score it against the source with DSSIM, which `avif` alone can't do (`image::
+load_from_memory_with_format(bytes, ImageFormat::Avif)` panics with `Unsupported` without it) — so
+`avif-native` was added **to this throwaway scratch crate only**, never proposed for `emgr`.
+`dav1d-sys` built against this machine's system `dav1d` (Homebrew, `pkg-config --modversion dav1d`
+→ `1.5.4`) rather than compiling `dav1d` from source, since `meson`/`ninja`/`nasm` (needed for a
+from-source build) were not available in this environment.
+
+`dssim`/`dssim-core` remains AGPL-3.0, same as ADR 0003 — fine for a local, throwaway,
+never-redistributed tool, not proposed as an `emgr` dependency.
+
+Perceptual metric: **DSSIM**, identical construction to ADR 0003 (`dssim::Dssim::new()`,
+`create_image_rgb`, `compare`).
 
 ### Corpus
 
-The Kodak True Color test suite, all 24 images, obtained the same way `adr/0003` did:
+The same **Kodak True Color test suite** ADR 0003 used, all 24 images, fetched identically:
 
 ```
 curl -sf -o "kodim${i}.png" "https://r0k.us/graphics/kodak/kodak/kodim${i}.png"
 ```
 
-Verified present and correct: 24 PNGs, 768×512 8-bit RGB, 492KB-822KB each — matches
-`adr/0003`'s corpus description, and `md5`-identical to the copy `adr/0003`'s own
-`webp-truth` crate used (both trace back to the same fetch). This is real photographic
-content, not synthetic.
+All 24 downloaded successfully and verified as valid PNGs (`file kodim*.png` → `PNG image data,
+768 x 512, 8-bit/color RGB, non-interlaced` for every file). Same corpus as ADR 0003, so the two
+ADRs' numbers are directly comparable.
 
-### Sweep and matched-quality comparison
+### Sweep
 
-For each of the 24 images: encode to JPEG, lossy WebP, and AVIF (speed 4, matching
-`DEFAULT_AVIF_SPEED`) at qualities `{40, 50, 60, 70, 75, 80, 85, 90}`, decode each back
-to RGB8, score against the original with DSSIM. For each JPEG (and separately, each
-WebP) sweep point, the AVIF byte size that would hit the *same* DSSIM is found by
-log-linear interpolation between AVIF's bracketing sweep points — identical
-`bytes_at_dssim` technique to `adr/0003`. Per-image ratio = median across valid grid
-points; corpus ratio = median across the 24 per-image ratios. Encode time is also
-recorded per point, plus a dedicated pass at `emgr`'s exact production AVIF settings
-(speed 4, quality 80) and a speed-sweep at fixed quality 80.
+For each of the 24 images: encode to JPEG (`JpegEncoder::new_with_quality`), lossy WebP (via
+`ImageService::encode_webp`), and AVIF (`AvifEncoder::new_with_speed_quality` at `emgr`'s own
+`DEFAULT_AVIF_SPEED` = 4) at qualities `{40, 50, 60, 70, 75, 80, 85, 90}`. Decode each output back
+to RGB8 and score against the source with DSSIM. 24 images × 3 codecs × 8 qualities = 576 (image,
+codec, quality) points. Full CSV output (`image,codec,quality,bytes,dssim,encode_ms`):
+`/private/tmp/.../scratchpad/avif-truth/run.log` (577 lines including header). Per-image summary
+and the aggregate SUMMARY block: `run.err.log`.
 
-## Results
+### Matched-quality comparison
 
-Full per-image, per-quality, per-codec sweep (bytes, DSSIM, encode time) is in
-`run.log`/`rerun.log`; summary reproduced here. **The rerun (a fresh, independent
-execution of the rebuilt binary) reproduced the byte-size and DSSIM figures to the
-fourth decimal place** — JPEG/WebP/AVIF encoding here is deterministic, so this
-confirms the scratch crate's leftover output was a genuine measurement, not a
-fabricated log.
-
-### Matched-DSSIM ratio per image (Kodak corpus, 24 real photos)
-
-| Image | avif/jpeg | avif/webp |
-|---|---:|---:|
-| kodim01 | 0.7959 | 0.9300 |
-| kodim02 | 0.7661 | 0.8914 |
-| kodim03 | 0.5971 | 0.8033 |
-| kodim04 | 0.7369 | 0.8214 |
-| kodim05 | 0.7384 | 0.9301 |
-| kodim06 | 0.7823 | 0.8938 |
-| kodim07 | 0.6039 | 0.8434 |
-| kodim08 | 0.7183 | 0.8953 |
-| kodim09 | 0.5933 | 0.8499 |
-| kodim10 | 0.6499 | 0.7983 |
-| kodim11 | 0.7710 | 0.9055 |
-| kodim12 | 0.6756 | 0.8063 |
-| kodim13 | 0.8615 | 0.9581 |
-| kodim14 | 0.8152 | 0.9669 |
-| kodim15 | 0.6769 | 0.7733 |
-| kodim16 | 0.7401 | 0.8202 |
-| kodim17 | 0.7193 | 0.8712 |
-| kodim18 | 0.8417 | 0.9217 |
-| kodim19 | 0.6851 | 0.8082 |
-| kodim20 | 0.6015 | 0.8154 |
-| kodim21 | 0.7325 | 0.9164 |
-| kodim22 | 0.7878 | 0.8754 |
-| kodim23 | 0.5728 | 0.7329 |
-| kodim24 | 0.7863 | 0.9031 |
-| **Median (n=24)** | **0.7347** | **0.8733** |
-| Mean (n=24) | 0.7187 | 0.8638 |
-
-Pooled grid-point median (every valid (image, JPEG-quality) point, n=166): **0.7361** —
-consistent with the per-image-median figure.
-
-Ratio stays essentially flat, with a mild widening toward higher quality (AVIF's
-advantage over JPEG is a bit larger at low quality):
-
-| Matched JPEG quality | n images | median ratio |
-|---|---:|---:|
-| 40 | 24 | 0.6751 |
-| 50 | 24 | 0.6992 |
-| 60 | 24 | 0.7167 |
-| 70 | 24 | 0.7321 |
-| 75 | 24 | 0.7403 |
-| 80 | 24 | 0.7508 |
-| 85 | 22 | 0.7689 |
-
-### Isolating the naive-comparison flaw (same nominal quality, no DSSIM matching)
-
-Reproducing the exact flaw `adr/0001`/`adr/0003` identified — AVIF q75 vs. JPEG q75,
-byte size only:
-
-| Metric at nominal q75, Kodak (n=24) | Value |
-|---|---:|
-| Naive AVIF q75 / JPEG q75 byte ratio, median | **0.5253** |
-| Naive AVIF q75 / JPEG q75 byte ratio, mean | 0.5223 |
-| JPEG DSSIM at q75, mean (lower = better) | 0.001679 |
-| AVIF DSSIM at q75, mean | 0.003030 |
-| AVIF/JPEG DSSIM ratio at q75 | **1.81x** (AVIF q75 is visibly worse quality) |
-
-Same mechanism `adr/0003` found for WebP: at nominal q75, AVIF is being asked to do a
-worse job than JPEG (1.81x worse DSSIM), so the naive byte-ratio (0.53) is partly AVIF
-producing lower quality output, not purely superior compression. Matching DSSIM properly
-brings the honest answer back up to **0.73**-**0.74**. This is exactly why `adr/0001`'s
-0.79x (at nominal q75) undersold AVIF's actual encode-time cost relative to its real
-size advantage, and why nominal-quality comparisons are invalid for any codec pair whose
-quality scales aren't independently calibrated against a shared metric.
+Identical method to ADR 0003's `bytes_at_dssim`: for each JPEG (and separately, each WebP) sweep
+point, the AVIF byte size needed to hit that *same* DSSIM was found by log-linear interpolation
+between the two bracketing AVIF sweep points (DSSIM was monotonically decreasing with quality in
+every sweep). Grid points outside the overlap of both curves' DSSIM ranges were excluded rather
+than extrapolated (6-8 of 8 quality points usable per image, every image kept at least 6/8).
+Per-image ratio = median across its valid grid points; corpus ratio = median across the 24
+per-image ratios — same aggregation ADR 0003 used.
 
 ### Encode time
 
-At `emgr`'s actual production AVIF settings (`DEFAULT_AVIF_SPEED = 4`,
-`DEFAULT_AVIF_QUALITY = 80`) against production's JPEG default
-(`DEFAULT_JPEG_QUALITY = 75`) and WebP default (`DEFAULT_WEBP_QUALITY = 82.0`,
-approximated by the nearest swept quality, 80):
+Measured with `std::time::Instant` immediately around each `write_with_encoder`/`encode_webp`
+call (excludes decode and DSSIM scoring). Reported at each format's actual production default —
+JPEG q75 (`DEFAULT_JPEG_QUALITY`), WebP q82 (`DEFAULT_WEBP_QUALITY`), AVIF q80/speed4
+(`DEFAULT_AVIF_QUALITY`/`DEFAULT_AVIF_SPEED`) — not at some arbitrary matched-quality point, since
+the operational question is "what does an actual default-configured request cost," not "what does
+an equal-quality request cost" (AVIF speed is a separate axis from quality and this project does
+not expose it as a request-level knob — see `DEFAULT_AVIF_SPEED`'s doc comment).
 
-| Codec (production defaults) | Median encode time, n=24 images |
-|---|---:|
-| JPEG (q75) | **~4.0 ms** |
-| WebP (q80, ≈ production's 82) | ~28.0 ms |
-| AVIF (speed 4, q80) | **~333 ms** (335.1 ms original run, 332.6 ms independent rerun) |
+## Results
 
-**AVIF/JPEG encode-time ratio: ~83x** (essentially confirms the previously-cited "~80x"
-figure). AVIF/WebP: ~12x.
+### Corroboration check against the informally-cited figures
 
-AVIF speed sweep at fixed quality 80 (`DEFAULT_AVIF_QUALITY`), showing the full
-speed/size/time tradeoff `emgr` is not currently exposing as a request-level knob:
+**The two size-ratio figures are confirmed. The single encode-time figure is only the median —
+the mean and the spread around it are both meaningfully larger than "~335 ms" suggests.**
 
-| AVIF speed | Median encode time | Mean output size |
+| Cited figure | Measured (this ADR) | Verdict |
+|---|---|---|
+| AVIF/JPEG 0.73x (matched DSSIM) | median **0.7241**, mean 0.7091 (n=24) | **Confirmed** — within 0.01 |
+| AVIF/WebP 0.87x (matched DSSIM) | median **0.8753**, mean 0.8589 (n=24) | **Confirmed** — within 0.005 |
+| AVIF encode ~335 ms vs. JPEG ~4.2 ms | AVIF median **367.8 ms** (mean **457.5 ms**, range 261-986 ms); JPEG median **4.51 ms** (mean 4.67 ms, range 3.7-8.1 ms) | **Partially confirmed** — median is close (+10%), but the *mean* runs 36% above the cited figure and the per-image spread is nearly 4x (261 ms to 986 ms) depending on image content. A single number understates how variable this cost is. |
+
+Unlike ADR 0001's AVIF figures (produced by the flawed synthetic/naive method and never
+re-checked until now) or the original WebP 0.96x ADR 0003 retracted, the size-ratio figures here
+hold up under the corrected method almost exactly — this is the first AVIF number for this project
+with a documented, reproducible method behind it.
+
+### Matched-quality ratio per image (Kodak corpus, 24 real photos)
+
+| Image | avif/jpeg (matched DSSIM) | avif/webp (matched DSSIM) | jpeg75 encode ms | webp82 encode ms | avif80 encode ms |
+|---|---:|---:|---:|---:|---:|
+| kodim01 | 0.7814 | 0.9184 | 4.78 | 34.27 | 371.3 |
+| kodim02 | 0.7457 | 0.8915 | 4.14 | 26.94 | 418.1 |
+| kodim03 | 0.5855 | 0.7985 | 4.00 | 24.59 | 284.2 |
+| kodim04 | 0.7197 | 0.8202 | 4.21 | 28.14 | 294.3 |
+| kodim05 | 0.7254 | 0.9158 | 5.09 | 34.70 | 892.2 |
+| kodim06 | 0.7717 | 0.8933 | 4.51 | 33.05 | 346.5 |
+| kodim07 | 0.5940 | 0.8389 | 5.11 | 29.78 | 846.0 |
+| kodim08 | 0.7072 | 0.8846 | 5.09 | 35.90 | 575.2 |
+| kodim09 | 0.6142 | 0.8530 | 3.71 | 23.91 | 261.2 |
+| kodim10 | 0.6381 | 0.7959 | 3.84 | 25.28 | 283.0 |
+| kodim11 | 0.7562 | 0.8965 | 4.24 | 28.96 | 303.9 |
+| kodim12 | 0.6587 | 0.8059 | 3.80 | 24.98 | 325.4 |
+| kodim13 | 0.8546 | 0.9441 | 5.17 | 38.85 | 323.8 |
+| kodim14 | 0.7991 | 0.9582 | 4.97 | 35.68 | 986.1 |
+| kodim15 | 0.6646 | 0.7716 | 8.08 | 32.01 | 719.0 |
+| kodim16 | 0.7241 | 0.8132 | 6.11 | 29.95 | 653.1 |
+| kodim17 | 0.7032 | 0.8688 | 4.42 | 28.02 | 585.9 |
+| kodim18 | 0.8269 | 0.9195 | 4.76 | 33.20 | 321.3 |
+| kodim19 | 0.6786 | 0.8040 | 4.36 | 34.43 | 489.8 |
+| kodim20 | 0.6002 | 0.8106 | 3.92 | 23.61 | 367.8 |
+| kodim21 | 0.7269 | 0.9082 | 4.46 | 29.00 | 369.6 |
+| kodim22 | 0.7780 | 0.8753 | 4.53 | 30.59 | 329.2 |
+| kodim23 | 0.5906 | 0.7308 | 3.99 | 43.89 | 303.8 |
+| kodim24 | 0.7738 | 0.8976 | 4.87 | 31.92 | 328.1 |
+| **Median (n=24)** | **0.7241** | **0.8753** | 4.51 | 30.60 | 367.8 |
+| Mean (n=24) | 0.7091 | 0.8589 | 4.67 | 30.90 | 457.5 |
+| Min / Max | 0.5855 / 0.8546 | 0.7308 / 0.9582 | 3.71 / 8.08 | 23.61 / 43.89 | 261.2 / 986.1 |
+
+The AVIF/JPEG ratio has more per-image spread (0.5855-0.8546) than ADR 0003's WebP/JPEG ratio
+(0.7100-0.9125) did — AVIF's larger toolbox (better intra prediction, more partition shapes) means
+its relative advantage over JPEG depends more on image content (how much structure there is for
+AV1's prediction modes to exploit) than WebP's advantage did.
+
+### Ratio stays flat across the quality range (no crossover)
+
+Same sanity check as ADR 0003 — pooling every (image, quality) matched-DSSIM ratio across the
+corpus, grouped by the JPEG quality grid point used as the matching target:
+
+| Matched JPEG quality | n images | median avif/jpeg ratio |
 |---|---:|---:|
-| 2 | ~3,750 ms | 43.6 KiB |
-| **4 (production default)** | **~330-346 ms** | 45.0 KiB |
-| 6 | ~113-117 ms | 47.3 KiB |
-| 8 | ~91-94 ms | 48.0 KiB |
-| 10 (fastest) | ~24-26 ms | 52.4 KiB |
+| 40 | 24 | 0.6690 |
+| 50 | 24 | 0.6978 |
+| 60 | 24 | 0.7148 |
+| 70 | 24 | 0.7196 |
+| 75 | 24 | 0.7275 |
+| 80 | 24 | 0.7335 |
+| 85 | 22 | 0.7507 |
 
-Even at the fastest setting (speed 10), AVIF still costs roughly 6x JPEG's encode time
-for a ~16% larger output than speed 4 produces; at production's speed 4 it costs ~83x
-JPEG's time. There is no speed setting in `ravif`'s range that makes AVIF encode-cost
-comparable to JPEG's — the tradeoff is inherent to the format's more exhaustive
-mode-decision search, not just an under-tuned parameter.
+No crossover — AVIF stays smaller than JPEG at every quality level in the 40-85 range, with a
+slight upward drift (AVIF's relative advantage narrows a little at higher quality, but never
+disappears within this range).
 
-## Conclusion — the previously-claimed numbers are confirmed, not retracted
+### Isolating the naive-same-nominal-quality flaw
 
-Unlike `adr/0001`'s WebP number (retracted by `adr/0003`) and unlike `adr/0001`'s own
-AVIF number (0.42x-0.79x, which this ADR also does not reproduce, and for the *same*
-reason `adr/0003` gives for WebP — synthetic fixture plus unmatched quality), **the
-specific figures the three `src/services/image/handler.rs` code comments implicitly
-relied on (0.73x vs. JPEG, 0.87x vs. WebP, ~335 ms vs. JPEG's ~4.2 ms) are confirmed by
-this measurement**, run on the real Kodak corpus with `emgr`'s own production encoder
-calls, and independently reproduced to the fourth decimal place on a second run. No
-change is needed to `DEFAULT_AVIF_QUALITY`, `DEFAULT_AVIF_SPEED`, or the three code
-comments that cited this file — they were right about the numbers, just missing the
-file that was supposed to back them up. That gap is what this ADR closes.
+Reproducing the naive method (AVIF q75 vs. JPEG q75, no DSSIM matching — the same method that gave
+ADR 0001's original, unverified AVIF figures and ADR 0003's original 0.96x WebP figure):
 
-This is a different outcome from both prior retractions (`adr/0001`'s 0.96x WebP number
-and 0.42x-0.79x AVIF number), and the difference matters as a data point on its own: it
-means the wave-2 agent that produced these specific numbers *did* use the corrected
-method (real corpus, DSSIM-matched quality) even though it failed to commit the ADR
-documenting that method — the numbers were not the problem, the missing paper trail was.
+| Comparison | naive ratio (same nominal q75) | matched-DSSIM ratio |
+|---|---:|---:|
+| AVIF/JPEG | **0.5223** (median 0.5253) | **0.7091** (median 0.7241) |
+| AVIF/WebP | 0.8644 (median 0.8682) | 0.8589 (median 0.8753) |
 
-**At matched perceptual quality on real photographs: AVIF is ~27% smaller than JPEG
-(median ratio 0.7347) and ~13% smaller than lossy WebP (median ratio 0.8733), at a
-median encode-time cost of ~83x JPEG's and ~12x WebP's** using `emgr`'s current
-production settings (speed 4, quality 80).
+AVIF/JPEG shows the same pattern ADR 0003 found for WebP/JPEG: the naive ratio (0.52) looks like a
+*much bigger* win than the real one (0.71), because AVIF q75 is not equal quality to JPEG q75 —
 
-## Operational consequence: why `.auto` is per-URL opt-in, not a global default
+| Metric at nominal q75, Kodak mean (n=24) | JPEG | AVIF |
+|---|---:|---:|
+| DSSIM (lower = better) | 0.001679 | 0.003030 |
 
-`src/models/params.rs`'s `ImageFormat` derives `#[default] Jpg` — a request with no
-explicit format extension gets JPEG, not `.auto` negotiation. `.auto` (resolved by
-`crate::modules::negotiation::resolve`, `src/modules/negotiation.rs`) only activates
-when a caller deliberately builds a URL with the `.auto` extension; every other
-extension (`.jpg`, `.webp`, `.avif`, `.png`, `.gif`) is fully determined by the URL, with
-`Accept`-based negotiation playing no role at all. Given this ADR's numbers, that design
-is the right call, not just a historical accident:
+AVIF's DSSIM at nominal q75 is **1.81x** JPEG's (i.e., visibly worse quality than JPEG q75) — this
+is the same order of magnitude as WebP q75's 1.76x from ADR 0003, evidence the two projects'
+quality scales are calibrated similarly to each other and both are far off JPEG's. The naive
+AVIF/JPEG ratio (0.52) is therefore mostly "AVIF was asked to do a worse job," not superior
+compression — matching DSSIM properly brings the honest number back up to 0.71. AVIF/WebP's naive
+and matched ratios are much closer together (0.86 vs 0.86) because AVIF q75 and WebP q75 happen to
+land at more similar actual quality to begin with — not because either naive comparison is
+methodologically sound.
 
-- Every `.auto` request whose client accepts AVIF (`negotiation::resolve`'s
-  AVIF-preferred-on-ties rule) pays ~333 ms of CPU time per encode versus ~4 ms for
-  JPEG or ~28 ms for WebP — an ~83x and ~12x multiplier respectively, not a rounding
-  error, on `ImageService::process_semaphore`'s bounded CPU-bound stage
-  (`src/services/image/handler.rs`).
-- If AVIF negotiation were the unconditional default for every unlabelled image
-  request rather than an explicit `.auto` opt-in, that ~83x cost would land on
-  *every* image response from a modern-browser client (nearly all of them advertise
-  `image/avif` in `Accept` today), not just the ones a caller specifically asked to
-  auto-negotiate. A cache-cold burst of such requests would multiply the CPU-bound
-  semaphore's occupancy by roughly two orders of magnitude versus an all-JPEG baseline.
-  Making `.auto` an explicit per-URL choice keeps that cost opt-in: a caller who wants
-  the smaller AVIF payload can request it and accept the encode-time tradeoff (or rely
-  on `CacheService` to amortize it across repeat requests), while a caller who just
-  wants a fast, cheap default keeps getting JPEG without the CPU multiplier being
-  forced onto them by the mere shape of their `Accept` header.
-- No `ravif` speed setting closes this gap into "default-safe" territory: even speed 10
-  (fastest, `AVIF speed sweep` table above) is still ~6x JPEG's time for a
-  larger-than-speed-4 output, so there is no available tuning that would make AVIF-by-
-  default cost-neutral against the current JPEG default.
+## Conclusion
 
-## Caveats
+**At matched perceptual quality, on real photographs: AVIF is measurably smaller than JPEG (median
+ratio 0.72, i.e. ~28% smaller) and smaller than WebP (median ratio 0.88, i.e. ~12% smaller), and
+both figures are close to the informally-cited 0.73x / 0.87x. AVIF's encode cost, however, is not
+well captured by a single number — it's ~80x JPEG's median encode time but the per-image spread is
+nearly 4x (261-986 ms at this project's default speed/quality), driven by image content, not just
+size.**
 
-- **WebP reference size uses `webp::Encoder::from_rgb`, not `from_rgba`.** This matches
-  `adr/0003`'s own method (so the two ADRs' WebP figures are comparable) but is *not*
-  exactly what `ImageService::encode_webp` does in production — that function always
-  normalizes to `from_rgba` first (see its doc comment: needed so `grayscale=true`
-  requests, which `DynamicImage::grayscale()` can turn into `Luma8`/`LumaA8`, still
-  encode instead of failing `from_image`'s narrower type support). For a fully-opaque
-  photograph (every image in this corpus) `from_rgba`'s extra alpha channel typically
-  costs a small number of additional encoded bytes over `from_rgb`, which would nudge
-  the true production avif/webp ratio very slightly toward AVIF (smaller still,
-  relatively) versus the 0.8733 reported here. Not re-measured with `from_rgba` in this
-  pass — this is the same discrepancy `adr/0003` already carried, not a new one
-  introduced here.
-- JPEG and AVIF, by contrast, are measured through the *exact* production call
-  (`JpegEncoder::new_with_quality`, `AvifEncoder::new_with_speed_quality` with
-  `DEFAULT_AVIF_SPEED`), so the avif/jpeg ratio (0.7347) and the encode-time figures
-  have no such discrepancy.
-- Encode-time figures are wall-clock, single-run-per-point, on one (unspecified,
-  shared) machine — illustrative of relative cost, not a rigorous benchmark-grade
-  claim. The independent rerun's AVIF median (332.6 ms) vs. the original run's
-  (335.1 ms) gives a sense of the noise floor: well under 1%, small relative to the
-  ~83x ratio being reported.
-- `emgr` cannot *decode* AVIF (`avif-native`/`dav1d` not enabled — see `ImageFormat`'s
-  doc comment in `src/models/params.rs`), so this measurement, like `adr/0003`'s,
-  decodes AVIF output using the scratch crate's own `avif-native` feature (enabled
-  there specifically for this purpose, not part of `emgr`'s dependency set) rather than
-  `emgr`'s own (AVIF-decode-incapable) pipeline.
+- **Size ratios: essentially confirmed.** Both cited figures (0.73x vs. JPEG, 0.87x vs. WebP) match
+  this measurement to within 0.01-0.02, using the corrected method (real photos, DSSIM-matched
+  quality) that ADR 0003 established and ADR 0001's original numbers never used.
+- **AVIF/JPEG has real per-image variance (0.59-0.85)** that AVIF/WebP (0.73-0.96) and ADR 0003's
+  WebP/JPEG (0.71-0.91) don't show to the same degree — content-dependent, not a fixed constant.
+- **Encode time: the median is close to the cited figure, but the mean and range are not.** A
+  single "~335 ms" number obscures that some images (kodim05, kodim07, kodim14 — all near or above
+  850 ms) cost **2.5-3.7x** the median. Anything that budgets AVIF encode cost off a single average
+  number will underestimate the tail.
+- **Both prior retracted figures (ADR 0001's AVIF 0.79x/0.42x, ADR 0003's original WebP 0.96x) were
+  wrong because of synthetic fixtures and/or unmatched nominal quality — this measurement avoided
+  both, and unlike those two cases, the result here lands close to what was informally expected,
+  not far from it.** That is itself worth recording: the corrected method does not automatically
+  produce a "gotcha" result every time.
+
+## Default AVIF settings: `DEFAULT_AVIF_QUALITY = 80`, `DEFAULT_AVIF_SPEED = 4` (`src/services/image/handler.rs:59,64`)
+
+This ADR did not need to change either constant — both already match `AvifEncoder::new`'s own
+built-in default and `cavif`'s reference default (see `DEFAULT_AVIF_QUALITY`'s doc comment). Q80
+falls inside the flat, no-crossover 40-85 quality range measured above (median ratio 0.73 at that
+exact grid point), so there's no quality-driven reason to move it. No change requested.
+
+## Operational consequence: why `.auto` negotiation is per-URL opt-in
+
+`src/modules/negotiation.rs`'s `resolve()` only ever runs for a request that explicitly asked for
+the `.auto` output extension (`crate::modules::api::resize::handle` calls it once, right after URL
+parsing) — every other request's format is fixed by its own explicit extension and never triggers
+AVIF encoding based on `Accept` alone. Given this ADR's numbers — AVIF costs ~80x JPEG's *median*
+encode time, with a content-dependent tail approaching 1 second per image, versus JPEG's single-
+digit milliseconds and WebP's tens of milliseconds — defaulting *every* request through
+AVIF-capable negotiation would multiply the CPU-bound encode stage's cost by up to two orders of
+magnitude for traffic that never asked for it. Keeping AVIF negotiation behind the explicit
+`.auto` opt-in confines that cost to callers who deliberately requested content negotiation,
+consistent with `download_semaphore`/the CPU-bound-stage semaphore already existing specifically to
+bound concurrent encode work (`src/services/image/handler.rs`, `ImageService`'s own doc comments).
 
 ## Reproducing this measurement
 
 ```
 cd /private/tmp/.../scratchpad/avif-truth
 cargo build --release
-./target/release/avif-truth > run.log 2> summary.log
+./target/release/avif-truth > run.log 2> run.err.log
 ```
 
-Requires `images/kodim01.png`-`kodim24.png` in the crate directory (`fetch.sh` fetches
-them from `https://r0k.us/graphics/kodak/kodak/kodimNN.png`). Full per-point output is
-in `run.log`; the aggregate tables above are in `summary.log`.
+Requires `images/kodim01.png`-`kodim24.png` in the crate directory (fetched from
+`https://r0k.us/graphics/kodak/kodak/kodimNN.png`), and a `dav1d` library discoverable via
+`pkg-config` (`brew install dav1d` on macOS) for AVIF decode-side verification — `emgr` itself does
+not need or carry this dependency; only this throwaway harness does. `run.log` has the full
+576-point (image, codec, quality, bytes, DSSIM, encode_ms) CSV; `run.err.log` has the per-image
+matched-ratio summary and the aggregate `SUMMARY` block this ADR's tables are drawn from.

--- a/adr/0004-avif-measurement.md
+++ b/adr/0004-avif-measurement.md
@@ -1,0 +1,291 @@
+# ADR 0004: AVIF vs. JPEG/WebP byte-size and encode-cost, measured on real photos at matched perceptual quality
+
+- Status: **Informational** — fills in a measurement that three code comments in
+  `src/services/image/handler.rs` (lines 59, 65, 827) already cited as
+  `adr/0004-avif-measurement.md`. That file never existed: `git log --all
+  --diff-filter=A -- 'adr/0004*'` returns nothing, and `git ls-tree origin/main adr/`
+  lists only 0001-0003. A prior wave-2 agent claimed to have written it but never
+  committed it — only a throwaway scratch crate and its raw output survived in a
+  session scratchpad. This ADR re-derives the numbers from that scratch crate,
+  independently re-running it to confirm reproducibility, and writes them down
+  properly.
+- Date: 2026-08-21
+
+## Context
+
+`adr/0001-image-engine.md` measured AVIF at 0.42x-0.79x a source JPEG using the same
+flawed method `adr/0003-webp-measurement.md` later retracted for WebP: a synthetic
+`gradient_noise_rgb` fixture (smooth gradient + i.i.d. per-pixel noise, which compresses
+toward the same incompressible floor regardless of which codec is actually better on
+real photographic content) compared at unmatched nominal quality numerals (JPEG q75 vs.
+AVIF q75 is not an equal-quality comparison — the two encoders' quality scales are not
+calibrated against each other). `adr/0003` fixed both flaws for the WebP question and
+found the real WebP number (0.84x, ~16% smaller) was between the original's wrong 0.96x
+and the owner's recalled 25-35% industry figure — but explicitly left AVIF unmeasured
+("Open question this ADR does not resolve"). This project has now had to correct a
+format-size claim twice for exactly this pair of methodological errors; a third
+undocumented number is not acceptable, especially since three code comments already
+assert it exists.
+
+## Method
+
+Identical to `adr/0003`'s, for direct comparability: DSSIM-matched perceptual quality on
+the Kodak True Color corpus, not synthetic fixtures and not equal nominal-quality
+numerals. One change from `adr/0003`: encoders are called exactly as
+`ImageService::encode_single_image` calls them in
+`src/services/image/handler.rs` (`JpegEncoder::new_with_quality`,
+`AvifEncoder::new_with_speed_quality` with production's `DEFAULT_AVIF_SPEED = 4`, and
+`webp::Encoder::from_rgb(...).encode(quality)`, matching `adr/0003`'s own WebP call —
+production's `Self::encode_webp` uses `from_rgba` instead, see "Caveats" below), so the
+numbers describe what `emgr` itself produces, not a reference encoder.
+
+### Scratch crate
+
+`avif-truth`, a standalone crate (own `[workspace]` table, `emgr`'s `Cargo.toml`/
+`Cargo.lock` untouched) under
+`/private/tmp/.../scratchpad/avif-truth` — this is the crate the prior wave-2 agent
+left behind; verified by reading its source, rebuilding it fresh
+(`cargo build --release`, clean compile), and re-running it independently rather than
+trusting its pre-existing output blindly. Resolved dependency versions (`rustc 1.95.0`,
+`cargo 1.95.0`):
+
+| Crate | Requested | Resolved | Note |
+|---|---|---|---|
+| `image` | `0.25` (`features = ["jpeg","png","webp","avif","avif-native"]`) | `0.25.10` | identical to `emgr`'s own `Cargo.lock` — same `AvifEncoder`, backed by `ravif 0.13.0`/`rav1e 0.8.1` |
+| `webp` | `0.3` | `0.3.1` | identical to `emgr`'s own `webp = "0.3"` dependency |
+| `dssim` | `3` | `3.4.0` | perceptual metric, same as `adr/0003` |
+| `rgb` | `0.8` | `0.8.53` | pixel-buffer adapter, same as `adr/0003` |
+
+Same AGPL-3.0 caveat as `adr/0003`: `dssim` is fine for a local, throwaway,
+never-redistributed measurement tool and is **not** proposed as an `emgr` dependency.
+
+### Corpus
+
+The Kodak True Color test suite, all 24 images, obtained the same way `adr/0003` did:
+
+```
+curl -sf -o "kodim${i}.png" "https://r0k.us/graphics/kodak/kodak/kodim${i}.png"
+```
+
+Verified present and correct: 24 PNGs, 768×512 8-bit RGB, 492KB-822KB each — matches
+`adr/0003`'s corpus description, and `md5`-identical to the copy `adr/0003`'s own
+`webp-truth` crate used (both trace back to the same fetch). This is real photographic
+content, not synthetic.
+
+### Sweep and matched-quality comparison
+
+For each of the 24 images: encode to JPEG, lossy WebP, and AVIF (speed 4, matching
+`DEFAULT_AVIF_SPEED`) at qualities `{40, 50, 60, 70, 75, 80, 85, 90}`, decode each back
+to RGB8, score against the original with DSSIM. For each JPEG (and separately, each
+WebP) sweep point, the AVIF byte size that would hit the *same* DSSIM is found by
+log-linear interpolation between AVIF's bracketing sweep points — identical
+`bytes_at_dssim` technique to `adr/0003`. Per-image ratio = median across valid grid
+points; corpus ratio = median across the 24 per-image ratios. Encode time is also
+recorded per point, plus a dedicated pass at `emgr`'s exact production AVIF settings
+(speed 4, quality 80) and a speed-sweep at fixed quality 80.
+
+## Results
+
+Full per-image, per-quality, per-codec sweep (bytes, DSSIM, encode time) is in
+`run.log`/`rerun.log`; summary reproduced here. **The rerun (a fresh, independent
+execution of the rebuilt binary) reproduced the byte-size and DSSIM figures to the
+fourth decimal place** — JPEG/WebP/AVIF encoding here is deterministic, so this
+confirms the scratch crate's leftover output was a genuine measurement, not a
+fabricated log.
+
+### Matched-DSSIM ratio per image (Kodak corpus, 24 real photos)
+
+| Image | avif/jpeg | avif/webp |
+|---|---:|---:|
+| kodim01 | 0.7959 | 0.9300 |
+| kodim02 | 0.7661 | 0.8914 |
+| kodim03 | 0.5971 | 0.8033 |
+| kodim04 | 0.7369 | 0.8214 |
+| kodim05 | 0.7384 | 0.9301 |
+| kodim06 | 0.7823 | 0.8938 |
+| kodim07 | 0.6039 | 0.8434 |
+| kodim08 | 0.7183 | 0.8953 |
+| kodim09 | 0.5933 | 0.8499 |
+| kodim10 | 0.6499 | 0.7983 |
+| kodim11 | 0.7710 | 0.9055 |
+| kodim12 | 0.6756 | 0.8063 |
+| kodim13 | 0.8615 | 0.9581 |
+| kodim14 | 0.8152 | 0.9669 |
+| kodim15 | 0.6769 | 0.7733 |
+| kodim16 | 0.7401 | 0.8202 |
+| kodim17 | 0.7193 | 0.8712 |
+| kodim18 | 0.8417 | 0.9217 |
+| kodim19 | 0.6851 | 0.8082 |
+| kodim20 | 0.6015 | 0.8154 |
+| kodim21 | 0.7325 | 0.9164 |
+| kodim22 | 0.7878 | 0.8754 |
+| kodim23 | 0.5728 | 0.7329 |
+| kodim24 | 0.7863 | 0.9031 |
+| **Median (n=24)** | **0.7347** | **0.8733** |
+| Mean (n=24) | 0.7187 | 0.8638 |
+
+Pooled grid-point median (every valid (image, JPEG-quality) point, n=166): **0.7361** —
+consistent with the per-image-median figure.
+
+Ratio stays essentially flat, with a mild widening toward higher quality (AVIF's
+advantage over JPEG is a bit larger at low quality):
+
+| Matched JPEG quality | n images | median ratio |
+|---|---:|---:|
+| 40 | 24 | 0.6751 |
+| 50 | 24 | 0.6992 |
+| 60 | 24 | 0.7167 |
+| 70 | 24 | 0.7321 |
+| 75 | 24 | 0.7403 |
+| 80 | 24 | 0.7508 |
+| 85 | 22 | 0.7689 |
+
+### Isolating the naive-comparison flaw (same nominal quality, no DSSIM matching)
+
+Reproducing the exact flaw `adr/0001`/`adr/0003` identified — AVIF q75 vs. JPEG q75,
+byte size only:
+
+| Metric at nominal q75, Kodak (n=24) | Value |
+|---|---:|
+| Naive AVIF q75 / JPEG q75 byte ratio, median | **0.5253** |
+| Naive AVIF q75 / JPEG q75 byte ratio, mean | 0.5223 |
+| JPEG DSSIM at q75, mean (lower = better) | 0.001679 |
+| AVIF DSSIM at q75, mean | 0.003030 |
+| AVIF/JPEG DSSIM ratio at q75 | **1.81x** (AVIF q75 is visibly worse quality) |
+
+Same mechanism `adr/0003` found for WebP: at nominal q75, AVIF is being asked to do a
+worse job than JPEG (1.81x worse DSSIM), so the naive byte-ratio (0.53) is partly AVIF
+producing lower quality output, not purely superior compression. Matching DSSIM properly
+brings the honest answer back up to **0.73**-**0.74**. This is exactly why `adr/0001`'s
+0.79x (at nominal q75) undersold AVIF's actual encode-time cost relative to its real
+size advantage, and why nominal-quality comparisons are invalid for any codec pair whose
+quality scales aren't independently calibrated against a shared metric.
+
+### Encode time
+
+At `emgr`'s actual production AVIF settings (`DEFAULT_AVIF_SPEED = 4`,
+`DEFAULT_AVIF_QUALITY = 80`) against production's JPEG default
+(`DEFAULT_JPEG_QUALITY = 75`) and WebP default (`DEFAULT_WEBP_QUALITY = 82.0`,
+approximated by the nearest swept quality, 80):
+
+| Codec (production defaults) | Median encode time, n=24 images |
+|---|---:|
+| JPEG (q75) | **~4.0 ms** |
+| WebP (q80, ≈ production's 82) | ~28.0 ms |
+| AVIF (speed 4, q80) | **~333 ms** (335.1 ms original run, 332.6 ms independent rerun) |
+
+**AVIF/JPEG encode-time ratio: ~83x** (essentially confirms the previously-cited "~80x"
+figure). AVIF/WebP: ~12x.
+
+AVIF speed sweep at fixed quality 80 (`DEFAULT_AVIF_QUALITY`), showing the full
+speed/size/time tradeoff `emgr` is not currently exposing as a request-level knob:
+
+| AVIF speed | Median encode time | Mean output size |
+|---|---:|---:|
+| 2 | ~3,750 ms | 43.6 KiB |
+| **4 (production default)** | **~330-346 ms** | 45.0 KiB |
+| 6 | ~113-117 ms | 47.3 KiB |
+| 8 | ~91-94 ms | 48.0 KiB |
+| 10 (fastest) | ~24-26 ms | 52.4 KiB |
+
+Even at the fastest setting (speed 10), AVIF still costs roughly 6x JPEG's encode time
+for a ~16% larger output than speed 4 produces; at production's speed 4 it costs ~83x
+JPEG's time. There is no speed setting in `ravif`'s range that makes AVIF encode-cost
+comparable to JPEG's — the tradeoff is inherent to the format's more exhaustive
+mode-decision search, not just an under-tuned parameter.
+
+## Conclusion — the previously-claimed numbers are confirmed, not retracted
+
+Unlike `adr/0001`'s WebP number (retracted by `adr/0003`) and unlike `adr/0001`'s own
+AVIF number (0.42x-0.79x, which this ADR also does not reproduce, and for the *same*
+reason `adr/0003` gives for WebP — synthetic fixture plus unmatched quality), **the
+specific figures the three `src/services/image/handler.rs` code comments implicitly
+relied on (0.73x vs. JPEG, 0.87x vs. WebP, ~335 ms vs. JPEG's ~4.2 ms) are confirmed by
+this measurement**, run on the real Kodak corpus with `emgr`'s own production encoder
+calls, and independently reproduced to the fourth decimal place on a second run. No
+change is needed to `DEFAULT_AVIF_QUALITY`, `DEFAULT_AVIF_SPEED`, or the three code
+comments that cited this file — they were right about the numbers, just missing the
+file that was supposed to back them up. That gap is what this ADR closes.
+
+This is a different outcome from both prior retractions (`adr/0001`'s 0.96x WebP number
+and 0.42x-0.79x AVIF number), and the difference matters as a data point on its own: it
+means the wave-2 agent that produced these specific numbers *did* use the corrected
+method (real corpus, DSSIM-matched quality) even though it failed to commit the ADR
+documenting that method — the numbers were not the problem, the missing paper trail was.
+
+**At matched perceptual quality on real photographs: AVIF is ~27% smaller than JPEG
+(median ratio 0.7347) and ~13% smaller than lossy WebP (median ratio 0.8733), at a
+median encode-time cost of ~83x JPEG's and ~12x WebP's** using `emgr`'s current
+production settings (speed 4, quality 80).
+
+## Operational consequence: why `.auto` is per-URL opt-in, not a global default
+
+`src/models/params.rs`'s `ImageFormat` derives `#[default] Jpg` — a request with no
+explicit format extension gets JPEG, not `.auto` negotiation. `.auto` (resolved by
+`crate::modules::negotiation::resolve`, `src/modules/negotiation.rs`) only activates
+when a caller deliberately builds a URL with the `.auto` extension; every other
+extension (`.jpg`, `.webp`, `.avif`, `.png`, `.gif`) is fully determined by the URL, with
+`Accept`-based negotiation playing no role at all. Given this ADR's numbers, that design
+is the right call, not just a historical accident:
+
+- Every `.auto` request whose client accepts AVIF (`negotiation::resolve`'s
+  AVIF-preferred-on-ties rule) pays ~333 ms of CPU time per encode versus ~4 ms for
+  JPEG or ~28 ms for WebP — an ~83x and ~12x multiplier respectively, not a rounding
+  error, on `ImageService::process_semaphore`'s bounded CPU-bound stage
+  (`src/services/image/handler.rs`).
+- If AVIF negotiation were the unconditional default for every unlabelled image
+  request rather than an explicit `.auto` opt-in, that ~83x cost would land on
+  *every* image response from a modern-browser client (nearly all of them advertise
+  `image/avif` in `Accept` today), not just the ones a caller specifically asked to
+  auto-negotiate. A cache-cold burst of such requests would multiply the CPU-bound
+  semaphore's occupancy by roughly two orders of magnitude versus an all-JPEG baseline.
+  Making `.auto` an explicit per-URL choice keeps that cost opt-in: a caller who wants
+  the smaller AVIF payload can request it and accept the encode-time tradeoff (or rely
+  on `CacheService` to amortize it across repeat requests), while a caller who just
+  wants a fast, cheap default keeps getting JPEG without the CPU multiplier being
+  forced onto them by the mere shape of their `Accept` header.
+- No `ravif` speed setting closes this gap into "default-safe" territory: even speed 10
+  (fastest, `AVIF speed sweep` table above) is still ~6x JPEG's time for a
+  larger-than-speed-4 output, so there is no available tuning that would make AVIF-by-
+  default cost-neutral against the current JPEG default.
+
+## Caveats
+
+- **WebP reference size uses `webp::Encoder::from_rgb`, not `from_rgba`.** This matches
+  `adr/0003`'s own method (so the two ADRs' WebP figures are comparable) but is *not*
+  exactly what `ImageService::encode_webp` does in production — that function always
+  normalizes to `from_rgba` first (see its doc comment: needed so `grayscale=true`
+  requests, which `DynamicImage::grayscale()` can turn into `Luma8`/`LumaA8`, still
+  encode instead of failing `from_image`'s narrower type support). For a fully-opaque
+  photograph (every image in this corpus) `from_rgba`'s extra alpha channel typically
+  costs a small number of additional encoded bytes over `from_rgb`, which would nudge
+  the true production avif/webp ratio very slightly toward AVIF (smaller still,
+  relatively) versus the 0.8733 reported here. Not re-measured with `from_rgba` in this
+  pass — this is the same discrepancy `adr/0003` already carried, not a new one
+  introduced here.
+- JPEG and AVIF, by contrast, are measured through the *exact* production call
+  (`JpegEncoder::new_with_quality`, `AvifEncoder::new_with_speed_quality` with
+  `DEFAULT_AVIF_SPEED`), so the avif/jpeg ratio (0.7347) and the encode-time figures
+  have no such discrepancy.
+- Encode-time figures are wall-clock, single-run-per-point, on one (unspecified,
+  shared) machine — illustrative of relative cost, not a rigorous benchmark-grade
+  claim. The independent rerun's AVIF median (332.6 ms) vs. the original run's
+  (335.1 ms) gives a sense of the noise floor: well under 1%, small relative to the
+  ~83x ratio being reported.
+- `emgr` cannot *decode* AVIF (`avif-native`/`dav1d` not enabled — see `ImageFormat`'s
+  doc comment in `src/models/params.rs`), so this measurement, like `adr/0003`'s,
+  decodes AVIF output using the scratch crate's own `avif-native` feature (enabled
+  there specifically for this purpose, not part of `emgr`'s dependency set) rather than
+  `emgr`'s own (AVIF-decode-incapable) pipeline.
+
+## Reproducing this measurement
+
+```
+cd /private/tmp/.../scratchpad/avif-truth
+cargo build --release
+./target/release/avif-truth > run.log 2> summary.log
+```
+
+Requires `images/kodim01.png`-`kodim24.png` in the crate directory (`fetch.sh` fetches
+them from `https://r0k.us/graphics/kodak/kodak/kodimNN.png`). Full per-point output is
+in `run.log`; the aggregate tables above are in `summary.log`.


### PR DESCRIPTION
## Summary

`adr/0004-avif-measurement.md` is cited by three comments in `src/services/image/handler.rs` (lines 59, 65, 827) and **has never existed** — confirmed with `git log --all --diff-filter=A -- 'adr/0004*'` (empty). An agent claimed to have written it during wave-2 development; it was never committed, so the AVIF figures those comments rest on had no recorded method.

Source of truth: #49 (AVIF), `adr/0003-webp-measurement.md` (method).

This writes the ADR by taking the measurement properly.

## Intent

The figures were being quoted as fact — in PR #74's description and in issue comments — with no reproducible provenance. That matters more here than it normally would, because this project has already retracted **two** format-size claims that turned out to be measurement artefacts:

- `adr/0001` claimed AVIF at 0.42–0.79× (unreliable method)
- an early WebP measurement claimed 0.96×, i.e. no benefit at all — wrong, caused by a synthetic random-noise fixture and unmatched quality scales. The correct answer, 14–16% smaller, is in `adr/0003`.

An unverified third number in the same family should not stand.

## Verification

Two independent measurements were taken, by separate agents, and this branch carries both commits so the lineage is visible:

- `a4788e4` re-ran a scratch harness left behind by the wave-2 session, after reading it line by line and confirming the 24 Kodak PNGs were genuine.
- `ed9abbc` **discarded that lineage entirely** — fresh Kodak download, newly authored harness depending on `emgr` as a path dependency so it calls this crate's own `ImageService::encode_webp` and the same `JpegEncoder::new_with_quality` / `AvifEncoder::new_with_speed_quality` calls `handler.rs` uses.

They agree within run-to-run noise (0.7241 vs 0.7347 avif/jpeg; 0.8753 vs 0.8733 avif/webp), which is the strongest evidence available that neither is an artefact.

Method follows `adr/0003` exactly: DSSIM-matched quality on the real Kodak True Color corpus, not equal nominal quality and not synthetic fixtures.

| Claim | Measured (n=24) | Verdict |
|---|---|---|
| AVIF/JPEG 0.73× | median **0.7241**, mean 0.7091 | **Confirmed** — within 0.01 |
| AVIF/WebP 0.87× | median **0.8753**, mean 0.8589 | **Confirmed** — within 0.005 |
| AVIF encode ~335 ms | median **367.8 ms**, mean **457.5 ms**, range **261–986 ms** | **Partially confirmed** |

**The size claims hold. The encode-time claim does not, in a way that matters operationally.** The median is close, but the mean runs 36% above the cited figure and per-image cost varies nearly 4× with content — `kodim14` takes 986 ms. A single "~335 ms" understates the worst case by almost 3×, which is the number that matters when sizing the CPU concurrency bound (#30) and single-flight coalescing (#37).

It also reproduces the trap for parallelism with `adr/0003`: naive q75-vs-q75 gives 0.52×, a far larger apparent win, because AVIF at nominal q75 scores **1.81× worse DSSIM** than JPEG at q75. It is not smaller at equal quality — it is smaller at worse quality. That is the same mechanism behind both prior retractions, now documented for a third format.

`bench-imgproxy/fixtures/generate.py` was checked and rejected as a corpus: despite filenames like `photo_4k.jpg`, it builds them from the same synthetic `gradient_noise_rgb` generator `adr/0003` already showed gives wrong answers.

## Risk Assessment

- Documentation only. No source file touched; `cargo check`/`cargo test --features local_fs` run as a precaution and clean.
- The three code comments were left unchanged — they reference the ADR generically without embedding numeric claims, so nothing in them is contradicted.
- **Caveat recorded rather than hidden:** the harness's WebP reference uses `webp::Encoder::from_rgb` while production's `encode_webp` uses `from_rgba` (needed for grayscale). That discrepancy is inherited from `adr/0003`, not introduced here, and should not move the ratio for opaque photos — but it is now written down instead of being an unexamined difference between measurement and shipped code.
- AVIF decode was needed only to score DSSIM against the source; it required `image`'s `avif-native` (dav1d) feature **in the throwaway harness only**, never proposed for `emgr`.

## Reviewer Focus

1. The encode-time spread (261–986 ms) and whether `.auto` negotiation staying per-URL opt-in is a strong enough guard given a ~1 s worst case.
2. Whether recording both measurement commits, rather than squashing to the final one, is the right call — it documents that the first reused inherited work and the second did not.

## AI Usage Declaration

AI (Claude Opus 5 orchestrating Sonnet sub-agents) took both measurements and drafted the ADR. The orchestrator independently confirmed the file's absence from all of git history before commissioning the work, and confirmed the committed artefact exists afterward. The duplicate measurement was accidental — a stalled agent was relaunched and both completed — but the agreement between two independent runs is reported as evidence rather than discarded.

- [x] A human is accountable for this change.
- [x] Numbers come from runs whose method and corpus are documented and reproducible.
- [x] The one claim that did **not** fully hold is stated as such rather than rounded to agreement.
