### PR TITLE
feat: progressive JPEG, chroma subsampling and max_bytes (#76)

### DIFF
--- a/.bench-baseline/BASELINE.md
+++ b/.bench-baseline/BASELINE.md
@@ -254,3 +254,51 @@ any code change:
    important architectural advantage for emgr, but not evidence that emgr
    processes images faster. **The cold numbers above are the processing
    comparison, and emgr loses those 3.65x (local_fs) / 3.56x (s3).**
+
+## JPEG encoder cutover — `feat/jpeg-encoder-options` (#76, 2026-08-21)
+
+#76 needed progressive-JPEG and chroma-subsampling control, which
+`image::codecs::jpeg::JpegEncoder` cannot express — its entire public API is
+`new`, `new_with_quality`, `set_pixel_density`, `encode`, `encode_image`,
+with 4:2:2 hardcoded. JPEG encoding therefore moved to `mozjpeg::Compress`
+(already a dependency since #63 stage 2). Same command/profile/machine as
+the sections above.
+
+| Bench | Before (`image` crate) | mozjpeg default profile | mozjpeg `JCP_FASTEST` (shipped) |
+|---|---:|---:|---:|
+| `encode/jpeg` | 3.07 ms | 9.61 ms | **0.95 ms** |
+| `pipeline photo_like → thumbnail_jpg` | 6.32 ms | 7.35 ms | **6.03 ms** |
+
+**The middle column is the trap, and it nearly shipped.** `mozjpeg::Compress::new`
+defaults to the `JCP_MAX_COMPRESSION` profile, whose `jpeg_set_defaults` sets
+`trellis_quant = (compress_profile == JCP_MAX_COMPRESSION)` — independent of
+the progressive toggle, so even non-progressive encodes paid full trellis
+cost. That is a +16% pipeline regression on the most common output format, in
+exchange for options most requests never use, and it would have failed the
+regression gate.
+
+Measured on the Kodak corpus at DSSIM-matched quality (the method in
+`adr/0003`), which is what settled it:
+
+| Encoder | Size | Time | Mean DSSIM @ nominal q75 |
+|---|---:|---:|---:|
+| `image` crate | 1.00× | 1.00× | 0.001678 |
+| mozjpeg `JCP_MAX_COMPRESSION` | 0.88× | 3–8× slower | 0.002236 |
+| mozjpeg `JCP_FASTEST` | 0.95× | 3–4× faster | 0.001787 |
+
+`JCP_FASTEST` beats the old encoder on size *and* speed simultaneously, and
+scores better DSSIM than the max-compression profile at the same nominal
+quality — trellis trades fidelity for size at a fixed quality knob, so
+dropping it does not make output worse. The extra ~7 percentage points of
+compression was not worth 3–8× CPU on every request; explicitly-requested
+progressive output still gets the full profile, because that cost is opted
+into.
+
+**Trap worth recording, alongside the three already in this file:** "mozjpeg
+compresses better than libjpeg" is true and was still the wrong default. The
+claim is about the max-compression profile, and nothing in the crate's API
+makes it obvious that merely constructing a `Compress` selects it.
+
+Note `encode/jpeg` is not directly comparable to the older tables above —
+this row is `encode/jpeg_baseline`, renamed when the progressive/subsampling
+variants were added alongside it.

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -1,26 +1,32 @@
 //! Encode-stage benchmarks: each output format the service supports.
 //!
-//! JPEG/PNG call `DynamicImage::write_to` - the same call
+//! PNG calls `DynamicImage::write_to` - the same call
 //! `ImageService::process_image_blocking` (src/services/image/handler.rs)
-//! makes for those formats' final encode step. WebP instead calls
+//! makes for that format's final encode step. WebP instead calls
 //! `ImageService::encode_webp`, the dedicated lossy-WebP path (via the
 //! `webp` crate) that `process_image_blocking` actually uses - the `image`
 //! crate's own WebP encoder that `write_to` would reach is lossless-only,
-//! so benchmarking it here would measure the wrong encoder.
+//! so benchmarking it here would measure the wrong encoder. JPEG (#76)
+//! similarly goes through `ImageService::encode_jpeg` (mozjpeg/
+//! libjpeg-turbo) rather than `write_to` - `image`'s own JPEG encoder has
+//! no progressive-mode switch and hardcodes 4:2:2 chroma subsampling, so
+//! production routes JPEG through mozjpeg instead (see `encode_jpeg`'s own
+//! doc comment). `jpeg_baseline`/`jpeg_progressive` below measure exactly
+//! that production path, both the encode-time cost and (via
+//! `benches/fixtures.rs`'s corpus, cross-checked against the in-repo
+//! `photo_like` fixture) the output-size delta #76's issue claims
+//! ("typically 2-10% smaller") - see this change's own report for the
+//! actual measured numbers on this corpus.
 
 #[path = "fixtures.rs"]
 mod fixtures;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use emgr::services::image::handler::{DEFAULT_WEBP_QUALITY, ImageService};
+use emgr::services::image::handler::{DEFAULT_JPEG_QUALITY, DEFAULT_WEBP_QUALITY, ImageService};
 use image::{DynamicImage, ImageFormat};
 use std::io::Cursor;
 
-const FORMATS: [(&str, ImageFormat); 3] = [
-    ("jpeg", ImageFormat::Jpeg),
-    ("png", ImageFormat::Png),
-    ("webp", ImageFormat::WebP),
-];
+const FORMATS: [(&str, ImageFormat); 2] = [("png", ImageFormat::Png), ("webp", ImageFormat::WebP)];
 
 /// A resized (800x450) photo-like image, representative of what actually
 /// reaches the encode step in production (post-download, post-resize).
@@ -48,6 +54,37 @@ fn bench_encode(c: &mut Criterion) {
                 }
             });
         });
+    }
+
+    // #76: JPEG now goes through `ImageService::encode_jpeg` (mozjpeg), not
+    // `write_to` - see this file's own doc comment. Four variants cover the
+    // two knobs #76 adds, each independently: baseline (pre-#76-equivalent
+    // default: 4:2:2, sequential), progressive (4:2:2 + progressive scans),
+    // and 4:4:4 (no_subsampling) at both scan modes, so the encode-time and
+    // output-size cost of each knob can be read off independently rather
+    // than conflated into one number.
+    for (name, progressive, no_subsampling) in [
+        ("jpeg_baseline", false, false),
+        ("jpeg_progressive", true, false),
+        ("jpeg_444", false, true),
+        ("jpeg_444_progressive", true, true),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(progressive, no_subsampling),
+            |b, &(progressive, no_subsampling)| {
+                b.iter(|| {
+                    ImageService::encode_jpeg(
+                        &img,
+                        DEFAULT_JPEG_QUALITY,
+                        progressive,
+                        no_subsampling,
+                        None,
+                    )
+                    .expect("encode fixture")
+                });
+            },
+        );
     }
 
     group.finish();

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -105,6 +105,21 @@ See the [API reference](../user-guide/api-reference.md) for the `wm:`/`wmu:`,
 | `PRESETS` | Preset definitions: comma-separated `{name}={options}` entries, `{options}` itself `/`-separated processing-option segments - e.g. `thumbnail=rs:fill:300:300/q:80,default=el:1`. A preset named `default` is special: it is prepended ahead of every request's own segments automatically, even when the request never names a preset at all. A preset's own definition cannot contain a `pr:` segment (presets don't recurse). imgproxy: *IMGPROXY_PRESETS*. | _unset_ |
 | `ALLOWED_PROCESSING_OPTIONS` | Comma-separated allowlist of processing-option short codes (e.g. `rs,q,pr`) permitted directly in a request URL. Unset/blank means unrestricted. Restricts what a request can do directly - it does **not** apply to options used *inside* a preset's own definition, which is what lets an operator hand out a restricted set of presets while forbidding the raw options they're built from. imgproxy: *IMGPROXY_ALLOWED_PROCESSING_OPTIONS*. | _unset_ (unrestricted) |
 
+## JPEG encoding
+
+Added under [GH #76](https://github.com/vaam-store/image-resizer/issues/76).
+JPEG output is encoded via `mozjpeg`/libjpeg-turbo rather than the `image`
+crate's own encoder, which has no progressive-mode switch and hardcodes
+4:2:2 chroma subsampling. See the [API reference](../user-guide/api-reference.md)
+for the `jpgo:{progressive}:{no_subsample}` and `mb:{bytes}` request-option
+syntax these variables set the deployment-wide default for - a request's
+own `jpgo:` segment always overrides these when present.
+
+| Variable | Description | Default |
+|---|---|---|
+| `JPEG_PROGRESSIVE` | Encode JPEG output progressively (multi-scan) instead of baseline sequential when a request doesn't set `jpgo:`'s `progressive` slot itself. Progressive JPEGs render incrementally and are often, but not always, smaller - see this change's own benchmark report rather than assuming a size win on every image. imgproxy: *IMGPROXY_JPEG_PROGRESSIVE*. | `false` |
+| `JPEG_NO_SUBSAMPLING` | Encode JPEG chroma at full resolution (4:4:4) instead of this crate's default 4:2:2 when a request doesn't set `jpgo:`'s `no_subsample` slot itself. 4:4:4 preserves colour detail on saturated edges (screenshots, logos, text on colour) at the cost of a larger file. imgproxy: *IMGPROXY_JPEG_NO_SUBSAMPLING*. | `false` |
+
 ## Performance tuning
 
 `PERFORMANCE_PROFILE` selects a preset (see

--- a/src/config/performance.rs
+++ b/src/config/performance.rs
@@ -65,6 +65,16 @@ pub struct PerformanceConfig {
     /// `ImageService::process_image`. Fetched through the same SSRF guard
     /// as any other source URL.
     pub watermark_url: Option<String>,
+    /// Deployment-wide default for `ResizeQuery::jpeg_progressive` when a
+    /// request's own `jpgo:` segment doesn't set the `progressive` slot
+    /// (#76). `false` (baseline sequential JPEG, matching this crate's
+    /// pre-#76 behaviour) unless `JPEG_PROGRESSIVE` says otherwise.
+    pub jpeg_progressive_default: bool,
+    /// Deployment-wide default for `ResizeQuery::jpeg_no_subsampling` when
+    /// a request's own `jpgo:` segment doesn't set the `no_subsample` slot
+    /// (#76). `false` (4:2:2 chroma, matching this crate's pre-#76
+    /// behaviour) unless `JPEG_NO_SUBSAMPLING` says otherwise.
+    pub jpeg_no_subsampling_default: bool,
 }
 
 impl Default for PerformanceConfig {
@@ -87,6 +97,8 @@ impl Default for PerformanceConfig {
             max_output_height: 4096,
             max_animation_frames: 512,
             watermark_url: None,
+            jpeg_progressive_default: false,
+            jpeg_no_subsampling_default: false,
         }
     }
 }
@@ -112,6 +124,8 @@ impl PerformanceConfig {
             max_output_height: 4096,
             max_animation_frames: 512,
             watermark_url: None,
+            jpeg_progressive_default: false,
+            jpeg_no_subsampling_default: false,
         }
     }
 
@@ -135,6 +149,8 @@ impl PerformanceConfig {
             max_output_height: 4096,
             max_animation_frames: 512,
             watermark_url: None,
+            jpeg_progressive_default: false,
+            jpeg_no_subsampling_default: false,
         }
     }
 
@@ -158,6 +174,8 @@ impl PerformanceConfig {
             max_output_height: 2048,
             max_animation_frames: 128, // tighter than the 512 default, same reasoning as the resolution/size caps above
             watermark_url: None,
+            jpeg_progressive_default: false,
+            jpeg_no_subsampling_default: false,
         }
     }
 
@@ -254,6 +272,14 @@ impl PerformanceConfig {
         if let Some(ref watermark_url) = env_config.watermark_url {
             config.watermark_url = Some(watermark_url.clone());
         }
+
+        if let Some(jpeg_progressive) = env_config.jpeg_progressive {
+            config.jpeg_progressive_default = jpeg_progressive;
+        }
+
+        if let Some(jpeg_no_subsampling) = env_config.jpeg_no_subsampling {
+            config.jpeg_no_subsampling_default = jpeg_no_subsampling;
+        }
     }
 
     /// Parses `ALLOWED_SOURCES`'s comma-separated-prefixes shape (imgproxy's
@@ -318,6 +344,8 @@ impl From<&EnvConfig> for PerformanceConfig {
             max_output_height: env_config.max_output_height.unwrap_or(4096),
             max_animation_frames: env_config.max_animation_frames.unwrap_or(512),
             watermark_url: env_config.watermark_url.clone(),
+            jpeg_progressive_default: env_config.jpeg_progressive.unwrap_or(false),
+            jpeg_no_subsampling_default: env_config.jpeg_no_subsampling.unwrap_or(false),
         }
     }
 }
@@ -425,6 +453,8 @@ mod tests {
             watermark_url: None,
             presets: None,
             allowed_processing_options: None,
+            jpeg_progressive: None,
+            jpeg_no_subsampling: None,
         };
 
         let perf_config = PerformanceConfig::from(&env_config);
@@ -446,6 +476,8 @@ mod tests {
         assert_eq!(perf_config.max_output_height, 4096);
         assert_eq!(perf_config.max_animation_frames, 512);
         assert_eq!(perf_config.watermark_url, None);
+        assert_eq!(perf_config.jpeg_progressive_default, false);
+        assert_eq!(perf_config.jpeg_no_subsampling_default, false);
     }
 
     #[test]
@@ -502,6 +534,8 @@ mod tests {
             watermark_url: Some("https://cdn.example.com/logo.png".to_string()),
             presets: None,
             allowed_processing_options: None,
+            jpeg_progressive: Some(true),
+            jpeg_no_subsampling: Some(true),
         };
 
         let perf_config = PerformanceConfig::from(&env_config);
@@ -532,6 +566,8 @@ mod tests {
             perf_config.watermark_url,
             Some("https://cdn.example.com/logo.png".to_string())
         );
+        assert_eq!(perf_config.jpeg_progressive_default, true);
+        assert_eq!(perf_config.jpeg_no_subsampling_default, true);
     }
 
     #[test]

--- a/src/models/params.rs
+++ b/src/models/params.rs
@@ -303,6 +303,48 @@ pub struct ResizeQuery {
     /// same as every other format-specific option in this struct.
     pub webp_lossless: Option<bool>,
 
+    // --- #76 additions start: progressive JPEG, chroma subsampling, and
+    // max_bytes. Kept as one contiguous block, mirroring the matching block
+    // in `src/services/cache/handler.rs`'s `generate_key` and
+    // `src/modules/url/options.rs`'s `ProcessingOptions`, so the three stay
+    // easy to cross-reference.
+    /// Encode JPEG output progressively instead of baseline sequential
+    /// (imgproxy's `jpeg_options`/`jpgo:{progressive}:...` option's first
+    /// slot, <https://docs.imgproxy.net/usage/processing#jpeg-options> -
+    /// only the `progressive`/`no_subsample` slots are implemented here,
+    /// see [`crate::modules::url::options::ProcessingOptions::jpeg_progressive`]
+    /// for why). `None` means "use this deployment's configured default"
+    /// (`PerformanceConfig::jpeg_progressive_default`, `JPEG_PROGRESSIVE`
+    /// env var - imgproxy's `IMGPROXY_JPEG_PROGRESSIVE`), resolved in
+    /// `ImageService::encode_single_image`. Meaningless for non-JPEG
+    /// output, same as every other format-specific option on this struct.
+    pub jpeg_progressive: Option<bool>,
+
+    /// Encode JPEG chroma at full resolution (4:4:4) instead of this
+    /// crate's default 4:2:2 (`jpgo:{progressive}:{no_subsample}`'s second
+    /// slot; imgproxy's `IMGPROXY_JPEG_NO_SUBSAMPLING`). `None` means "use
+    /// this deployment's configured default"
+    /// (`PerformanceConfig::jpeg_no_subsampling_default`,
+    /// `JPEG_NO_SUBSAMPLING` env var), same resolution point as
+    /// `jpeg_progressive` above. Meaningless for non-JPEG output.
+    pub jpeg_no_subsampling: Option<bool>,
+
+    /// Maximum encoded output size in bytes (imgproxy's `max_bytes`/
+    /// `mb:{bytes}` option). `None`/`Some(0)`-normalised-to-`None` (`mb`'s
+    /// URL parser follows the same "0 means unset" convention as
+    /// `width`/`height`) means no budget - the encoder just uses whatever
+    /// quality was otherwise resolved. When set, `ImageService` iteratively
+    /// lowers quality (bounded search - see
+    /// `ImageService::encode_with_max_bytes`) until the output fits, or the
+    /// search budget is exhausted, matching imgproxy's own documented
+    /// best-effort behaviour ("automatically degrades the quality... until
+    /// the image size is under the specified amount of bytes"). Only
+    /// applied to JPEG output - see `encode_single_image`'s JPEG branch for
+    /// the cost reasoning (measured against `benches/encode.rs`) behind
+    /// excluding every other format.
+    pub max_bytes: Option<u64>,
+    // --- #76 additions end.
+
     /// Background colour, as an `[R, G, B]` triple (imgproxy's
     /// `background`/`bg:{R}:{G}:{B}` or `bg:{hex}` processing option, #34).
     /// `None` means "use the default" - `ImageService` (`src/services/image/handler.rs`)
@@ -512,6 +554,9 @@ impl Default for ResizeQuery {
             jpeg_quality: None,
             webp_quality: None,
             webp_lossless: None,
+            jpeg_progressive: None,
+            jpeg_no_subsampling: None,
+            max_bytes: None,
             background: None,
             autorotate: true,
             crop: None,

--- a/src/modules/env/env.rs
+++ b/src/modules/env/env.rs
@@ -192,4 +192,20 @@ pub struct EnvConfig {
     /// equivalent: `IMGPROXY_ALLOWED_PROCESSING_OPTIONS`.
     #[envconfig(from = "ALLOWED_PROCESSING_OPTIONS")]
     pub allowed_processing_options: Option<String>,
+
+    // Progressive JPEG / chroma subsampling deployment defaults (#76)
+    /// Deployment-wide default for whether JPEG output is encoded
+    /// progressively when a request's own `jpgo:{progressive}:...` segment
+    /// doesn't say - see `ResizeQuery::jpeg_progressive`. imgproxy
+    /// equivalent: `IMGPROXY_JPEG_PROGRESSIVE`.
+    #[envconfig(from = "JPEG_PROGRESSIVE")]
+    pub jpeg_progressive: Option<bool>,
+
+    /// Deployment-wide default for whether JPEG output keeps full-
+    /// resolution (4:4:4) chroma when a request's own
+    /// `jpgo:{progressive}:{no_subsample}` segment doesn't say - see
+    /// `ResizeQuery::jpeg_no_subsampling`. imgproxy equivalent:
+    /// `IMGPROXY_JPEG_NO_SUBSAMPLING`.
+    #[envconfig(from = "JPEG_NO_SUBSAMPLING")]
+    pub jpeg_no_subsampling: Option<bool>,
 }

--- a/src/modules/url/mod.rs
+++ b/src/modules/url/mod.rs
@@ -195,6 +195,15 @@ impl ParsedRequest {
             jpeg_quality: self.options.jpeg_quality,
             webp_quality: self.options.webp_quality,
             webp_lossless: self.options.webp_lossless,
+            // #76: progressive JPEG, chroma subsampling, max_bytes. `None`
+            // for `jpeg_progressive`/`jpeg_no_subsampling` is resolved
+            // against this deployment's configured default later
+            // (`ImageService::encode_single_image`) - not here, since a
+            // `ParsedRequest` has no `PerformanceConfig` to resolve
+            // against.
+            jpeg_progressive: self.options.jpeg_progressive,
+            jpeg_no_subsampling: self.options.jpeg_no_subsampling,
+            max_bytes: self.options.max_bytes,
             background: self.options.background,
             autorotate: self.options.autorotate.unwrap_or(true),
             crop: self.options.crop,
@@ -417,6 +426,34 @@ mod tests {
         assert_eq!(wm.y_offset, 20.0);
         assert_eq!(wm.scale, 0.3);
         assert_eq!(wm.url, None);
+    }
+
+    /// #76: `jpgo`/`mb` round-trip through `into_resize_query` unresolved
+    /// (`jpeg_progressive`/`jpeg_no_subsampling` stay `Option<bool>` -
+    /// deployment-default resolution happens later, in
+    /// `ImageService::encode_single_image`, not here) - same "does the
+    /// wiring actually reach `ResizeQuery`" check every other option gets
+    /// its own dedicated test for.
+    #[test]
+    fn jpeg_options_and_max_bytes_round_trip_into_resize_query() {
+        let encoded = b64("https://example.com/img.jpg");
+        let path = format!("/SIG/jpgo:1:1/mb:20000/{encoded}.jpg");
+        let query = split(&path).unwrap().parse().unwrap().into_resize_query();
+
+        assert_eq!(query.jpeg_progressive, Some(true));
+        assert_eq!(query.jpeg_no_subsampling, Some(true));
+        assert_eq!(query.max_bytes, Some(20000));
+    }
+
+    #[test]
+    fn jpeg_options_and_max_bytes_default_to_none_when_absent() {
+        let encoded = b64("https://example.com/img.jpg");
+        let path = format!("/SIG/{encoded}.jpg");
+        let query = split(&path).unwrap().parse().unwrap().into_resize_query();
+
+        assert_eq!(query.jpeg_progressive, None);
+        assert_eq!(query.jpeg_no_subsampling, None);
+        assert_eq!(query.max_bytes, None);
     }
 
     #[test]

--- a/src/modules/url/options.rs
+++ b/src/modules/url/options.rs
@@ -37,6 +37,22 @@ pub struct ProcessingOptions {
     /// `webpo`'s parsed `compression` slot (#35) - see
     /// [`crate::models::params::ResizeQuery::webp_lossless`].
     pub webp_lossless: Option<bool>,
+
+    // --- #76 additions start: progressive JPEG, chroma subsampling,
+    // max_bytes. Kept contiguous, mirroring the matching block in
+    // `crate::models::params::ResizeQuery` and `generate_key`
+    // (`src/services/cache/handler.rs`).
+    /// `jpgo`'s parsed `progressive` slot (#76) - see
+    /// [`crate::models::params::ResizeQuery::jpeg_progressive`].
+    pub jpeg_progressive: Option<bool>,
+    /// `jpgo`'s parsed `no_subsample` slot (#76) - see
+    /// [`crate::models::params::ResizeQuery::jpeg_no_subsampling`].
+    pub jpeg_no_subsampling: Option<bool>,
+    /// `mb`'s parsed `{bytes}` argument (#76) - see
+    /// [`crate::models::params::ResizeQuery::max_bytes`].
+    pub max_bytes: Option<u64>,
+    // --- #76 additions end.
+
     /// `bg`'s parsed `[R, G, B]` triple (#34) - see
     /// [`crate::models::params::ResizeQuery::background`] for how it's
     /// consumed.
@@ -144,6 +160,9 @@ impl Default for ProcessingOptions {
             jpeg_quality: None,
             webp_quality: None,
             webp_lossless: None,
+            jpeg_progressive: None,
+            jpeg_no_subsampling: None,
+            max_bytes: None,
             background: None,
             autorotate: None,
             crop: None,
@@ -293,6 +312,60 @@ impl ProcessingOptions {
                             });
                         }
                     });
+                }
+                // jpgo:{progressive}:{no_subsample} - a deliberately partial
+                // implementation of imgproxy's `jpeg_options`/`jpgo:
+                // {progressive}:{no_subsample}:{trellis_quant}:
+                // {overshoot_deringing}:{optimize_scans}:{quant_table}`
+                // option (#76,
+                // <https://docs.imgproxy.net/usage/processing#jpeg-options>).
+                // Only the first two slots are implemented - `mozjpeg::Compress`
+                // (this crate's only route to progressive/subsampling
+                // control, see `ImageService::encode_jpeg`) has no direct
+                // equivalent of imgproxy's trellis-quantization/overshoot-
+                // deringing/quant-table knobs, so accepting and silently
+                // ignoring those slots would be a worse trap than rejecting
+                // them outright - same reasoning as `webpo`'s partial
+                // implementation just above. Each of the two implemented
+                // slots may be omitted (a shorter segment) or left blank
+                // (`jpgo:1:`) to keep its own default - "use this
+                // deployment's configured default"
+                // (`ResizeQuery::jpeg_progressive`/`jpeg_no_subsampling`),
+                // the same "empty positional argument means use the
+                // default" convention `fl`'s arguments already use.
+                "jpgo" => {
+                    if args.is_empty() || args.len() > 2 {
+                        return Err(UrlParseError::InvalidOptionValue {
+                            option: segment.to_string(),
+                            reason: "expected 1 or 2 arguments: progressive[:no_subsample] \
+                                     (trellis_quant/overshoot_deringing/optimize_scans/\
+                                     quant_table are not supported)"
+                                .to_string(),
+                        });
+                    }
+                    if let Some(progressive) = args.first().filter(|s| !s.is_empty()) {
+                        opts.jpeg_progressive = Some(parse_bool(progressive, segment)?);
+                    }
+                    if let Some(no_subsample) = args.get(1).filter(|s| !s.is_empty()) {
+                        opts.jpeg_no_subsampling = Some(parse_bool(no_subsample, segment)?);
+                    }
+                }
+                // mb:{bytes} - imgproxy's `max_bytes`/`mb` option (#76,
+                // <https://docs.imgproxy.net/usage/processing#max-bytes>).
+                // `0` means "not set", the same convention `rs`'s
+                // width/height slots already use - matches imgproxy's own
+                // documented default of `0` ("no limit"). Only ever
+                // consumed for JPEG output - see
+                // `ImageService::encode_single_image`'s JPEG branch for why
+                // every other format is excluded (cost, or no continuous
+                // quality axis to search over).
+                "mb" => {
+                    let [value] = require_args::<1>(&args, segment)?;
+                    let bytes: u64 = value.parse().map_err(|_| UrlParseError::InvalidOptionValue {
+                        option: segment.to_string(),
+                        reason: format!("{value:?} is not a valid unsigned integer"),
+                    })?;
+                    opts.max_bytes = if bytes == 0 { None } else { Some(bytes) };
                 }
                 "bl" => {
                     let [value] = require_args::<1>(&args, segment)?;
@@ -1085,6 +1158,77 @@ mod tests {
         // than silently ignoring the other two (see the `webpo` match arm's
         // doc comment).
         assert!(ProcessingOptions::parse(&["webpo:lossless::4"]).is_err());
+    }
+
+    // ---- #76: jpgo (progressive/no_subsample), mb (max_bytes) ----
+
+    #[test]
+    fn parses_jpeg_options_progressive_only() {
+        let opts = ProcessingOptions::parse(&["jpgo:1"]).unwrap();
+        assert_eq!(opts.jpeg_progressive, Some(true));
+        assert_eq!(opts.jpeg_no_subsampling, None);
+    }
+
+    #[test]
+    fn parses_jpeg_options_both_slots() {
+        let opts = ProcessingOptions::parse(&["jpgo:1:1"]).unwrap();
+        assert_eq!(opts.jpeg_progressive, Some(true));
+        assert_eq!(opts.jpeg_no_subsampling, Some(true));
+
+        let opts = ProcessingOptions::parse(&["jpgo:0:0"]).unwrap();
+        assert_eq!(opts.jpeg_progressive, Some(false));
+        assert_eq!(opts.jpeg_no_subsampling, Some(false));
+    }
+
+    #[test]
+    fn jpeg_options_empty_slot_keeps_default() {
+        // `jpgo:1:` leaves `no_subsample` at "use the deployment default"
+        // (`None`), same "empty positional argument" convention `fl` uses.
+        let opts = ProcessingOptions::parse(&["jpgo:1:"]).unwrap();
+        assert_eq!(opts.jpeg_progressive, Some(true));
+        assert_eq!(opts.jpeg_no_subsampling, None);
+    }
+
+    #[test]
+    fn jpeg_options_defaults_to_none_when_absent() {
+        let opts = ProcessingOptions::parse(&[]).unwrap();
+        assert_eq!(opts.jpeg_progressive, None);
+        assert_eq!(opts.jpeg_no_subsampling, None);
+    }
+
+    #[test]
+    fn jpeg_options_rejects_empty_and_too_many_arguments() {
+        assert!(ProcessingOptions::parse(&["jpgo"]).is_err());
+        // imgproxy's own 6-slot grammar - this crate only implements the
+        // first two (progressive, no_subsample), and rejects rather than
+        // silently ignoring trellis_quant/overshoot_deringing/
+        // optimize_scans/quant_table (see the `jpgo` match arm's doc
+        // comment).
+        assert!(ProcessingOptions::parse(&["jpgo:1:1:1"]).is_err());
+    }
+
+    #[test]
+    fn parses_max_bytes() {
+        let opts = ProcessingOptions::parse(&["mb:20000"]).unwrap();
+        assert_eq!(opts.max_bytes, Some(20000));
+    }
+
+    #[test]
+    fn max_bytes_zero_means_unset() {
+        let opts = ProcessingOptions::parse(&["mb:0"]).unwrap();
+        assert_eq!(opts.max_bytes, None);
+    }
+
+    #[test]
+    fn max_bytes_defaults_to_none_when_absent() {
+        let opts = ProcessingOptions::parse(&[]).unwrap();
+        assert_eq!(opts.max_bytes, None);
+    }
+
+    #[test]
+    fn max_bytes_rejects_non_integer() {
+        assert!(ProcessingOptions::parse(&["mb:not-a-number"]).is_err());
+        assert!(ProcessingOptions::parse(&["mb:-1"]).is_err());
     }
 
     #[test]

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -69,6 +69,21 @@ use sha2::{Digest, Sha256};
 /// changes the resize pipeline's output bytes, so two requests differing
 /// only in one of them must not collide onto a v7 key that never hashed
 /// it.
+///
+/// NOT bumped for #76 (progressive JPEG, chroma subsampling, `max_bytes`):
+/// `generate_key` below already hashes all three new fields (same
+/// output-affecting reasoning as every prior bump), but the version
+/// constant itself is deliberately left at v8 here - a concurrently-landing
+/// change may add its own hashed field around the same time, and bumping
+/// per-PR would either collide or waste a version number. Whoever
+/// integrates this leaves every v8 entry produced *without* these three
+/// fields hashed at all sitting behind a key that a post-#76 request would
+/// now compute differently anyway (the byte stream changed, even though
+/// the version byte didn't) - safe (no wrong-output serving, just an
+/// extra cache miss - see `generate_key`'s own doc comment on length-
+/// prefixed fields for why differing byte streams can't collide) but not
+/// free, so the actual version bump should still happen once, covering
+/// this and whatever else lands alongside it.
 const CACHE_KEY_VERSION: u8 = 8;
 
 #[derive(Clone, Builder)]
@@ -163,6 +178,38 @@ impl CacheService {
 
         match params.webp_lossless {
             Some(lossless) => Self::update_field(&mut hasher, lossless.to_string().as_bytes()),
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        // #76: `jpeg_progressive`/`jpeg_no_subsampling`/`max_bytes` all
+        // change the JPEG encoder's output bytes directly
+        // (`ImageService::encode_jpeg`/`encode_with_max_bytes`,
+        // `src/services/image/handler.rs`) - progressive vs baseline scan
+        // structure, 4:2:2 vs 4:4:4 chroma sampling, and the quality a
+        // `max_bytes` budget search actually lands on are all part of what
+        // gets encoded, exactly like `quality`/`jpeg_quality` above. Two
+        // requests differing only in one of these three must not collide
+        // onto the same cache key - added here per this change's own
+        // requirements; NOT yet covered by a `CACHE_KEY_VERSION` bump (see
+        // that constant's own doc comment - left for a single integrator
+        // bump alongside any other concurrently-landing change that also
+        // needs one, rather than each claiming its own number).
+        match params.jpeg_progressive {
+            Some(progressive) => {
+                Self::update_field(&mut hasher, progressive.to_string().as_bytes())
+            }
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.jpeg_no_subsampling {
+            Some(no_subsampling) => {
+                Self::update_field(&mut hasher, no_subsampling.to_string().as_bytes())
+            }
+            None => Self::update_field(&mut hasher, b"None"),
+        }
+
+        match params.max_bytes {
+            Some(max_bytes) => Self::update_field(&mut hasher, max_bytes.to_string().as_bytes()),
             None => Self::update_field(&mut hasher, b"None"),
         }
 
@@ -667,6 +714,94 @@ mod tests {
             keys.len(),
             3,
             "each distinct webp_lossless value (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #76: `jpeg_progressive` changes the JPEG encoder's scan structure
+    /// (`ImageService::encode_jpeg`'s `set_progressive_mode` call), so a
+    /// progressive and a baseline request for otherwise-identical
+    /// parameters must not collide onto the same cache key.
+    #[test]
+    fn jpeg_progressive_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |jpeg_progressive: Option<bool>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            jpeg_progressive,
+            ..Default::default()
+        };
+
+        let keys: HashSet<String> = [None, Some(false), Some(true)]
+            .into_iter()
+            .map(|p| cache.generate_key(&base(p)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct jpeg_progressive value (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #76: `jpeg_no_subsampling` changes the JPEG encoder's chroma
+    /// sampling (4:2:2 vs 4:4:4), so it must be part of the key like
+    /// `jpeg_progressive` above.
+    #[test]
+    fn jpeg_no_subsampling_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |jpeg_no_subsampling: Option<bool>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            jpeg_no_subsampling,
+            ..Default::default()
+        };
+
+        let keys: HashSet<String> = [None, Some(false), Some(true)]
+            .into_iter()
+            .map(|s| cache.generate_key(&base(s)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct jpeg_no_subsampling value (including unset) must produce a distinct cache key"
+        );
+    }
+
+    /// #76: `max_bytes` changes whichever quality `encode_with_max_bytes`'s
+    /// search actually lands on, so distinct budgets (and "no budget" -
+    /// `None`) must not collide.
+    #[test]
+    fn max_bytes_produces_distinct_keys() {
+        let cache = cache_service();
+
+        let base = |max_bytes: Option<u64>| ResizeQuery {
+            url: "https://ex.com/a.jpg".to_string(),
+            width: Some(100),
+            height: Some(100),
+            resize_type: ResizeType::Fit,
+            format: ImageFormat::Jpg,
+            max_bytes,
+            ..Default::default()
+        };
+
+        let keys: HashSet<String> = [None, Some(10_000), Some(20_000)]
+            .into_iter()
+            .map(|b| cache.generate_key(&base(b)))
+            .collect();
+
+        assert_eq!(
+            keys.len(),
+            3,
+            "each distinct max_bytes value (including unset) must produce a distinct cache key"
         );
     }
 

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -70,21 +70,23 @@ use sha2::{Digest, Sha256};
 /// only in one of them must not collide onto a v7 key that never hashed
 /// it.
 ///
-/// NOT bumped for #76 (progressive JPEG, chroma subsampling, `max_bytes`):
-/// `generate_key` below already hashes all three new fields (same
-/// output-affecting reasoning as every prior bump), but the version
-/// constant itself is deliberately left at v8 here - a concurrently-landing
-/// change may add its own hashed field around the same time, and bumping
-/// per-PR would either collide or waste a version number. Whoever
-/// integrates this leaves every v8 entry produced *without* these three
-/// fields hashed at all sitting behind a key that a post-#76 request would
-/// now compute differently anyway (the byte stream changed, even though
-/// the version byte didn't) - safe (no wrong-output serving, just an
-/// extra cache miss - see `generate_key`'s own doc comment on length-
-/// prefixed fields for why differing byte streams can't collide) but not
-/// free, so the actual version bump should still happen once, covering
-/// this and whatever else lands alongside it.
-const CACHE_KEY_VERSION: u8 = 8;
+/// v9 covers #76 (`jpeg_progressive`, `jpeg_no_subsampling`, `max_bytes`).
+/// All three change the encoder's output bytes directly - progressive
+/// rewrites the scan structure, subsampling changes chroma resolution, and
+/// `max_bytes` re-encodes at a lower quality until the result fits - so two
+/// requests differing only in one of them must not collide onto a v8 key
+/// that never hashed it.
+///
+/// #76 additionally re-routes JPEG encoding through `mozjpeg` at its
+/// `JCP_FASTEST` profile, replacing `image::codecs::jpeg::JpegEncoder`.
+/// That changes the produced bytes for *every* JPEG request, including ones
+/// using no new option at all - the output is perceptually equivalent
+/// (measured, not assumed) but not byte-identical. A cached v8 entry is
+/// therefore stale in a way no new hashed field would express, which is
+/// the second, independent reason this bump is required rather than merely
+/// tidy: without it, existing entries would keep being served from the old
+/// encoder indefinitely.
+const CACHE_KEY_VERSION: u8 = 9;
 
 #[derive(Clone, Builder)]
 pub struct CacheService {
@@ -189,11 +191,8 @@ impl CacheService {
         // `max_bytes` budget search actually lands on are all part of what
         // gets encoded, exactly like `quality`/`jpeg_quality` above. Two
         // requests differing only in one of these three must not collide
-        // onto the same cache key - added here per this change's own
-        // requirements; NOT yet covered by a `CACHE_KEY_VERSION` bump (see
-        // that constant's own doc comment - left for a single integrator
-        // bump alongside any other concurrently-landing change that also
-        // needs one, rather than each claiming its own number).
+        // onto the same cache key - covered by the v9 `CACHE_KEY_VERSION`
+        // bump (see that constant's own doc comment).
         match params.jpeg_progressive {
             Some(progressive) => {
                 Self::update_field(&mut hasher, progressive.to_string().as_bytes())

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -2057,6 +2057,59 @@ impl ImageService {
         let mut compress = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
         compress.set_size(width as usize, height as usize);
 
+        // Non-progressive path only: drop to mozjpeg's `JCP_FASTEST`
+        // profile (`set_fastest_defaults`, "reset to libjpeg v6 settings ...
+        // identical with libjpeg-turbo") before anything else is
+        // configured, so the size/quality-affecting calls below apply on
+        // top of it rather than being clobbered by it - `set_fastest_defaults`
+        // re-runs `jpeg_set_defaults` internally, which resets quality,
+        // colour-space-derived sampling factors, and everything else this
+        // function sets afterward (`mozjpeg-sys-2.2.3/vendor/jcparam.c`'s
+        // `jpeg_set_defaults`).
+        //
+        // Why: mozjpeg's *default* profile from `Compress::new` is
+        // `JCP_MAX_COMPRESSION`, which turns on trellis quantisation
+        // (`master->trellis_quant = true`) unconditionally at
+        // `jpeg_set_defaults` time - regardless of the progressive/
+        // `set_optimize_scans` setting below, since that's a separate,
+        // later, dynamic bool param that never touches `trellis_quant`
+        // (confirmed by reading `jcparam.c` directly: `trellis_quant =
+        // (compress_profile == JCP_MAX_COMPRESSION)`, set once, no public
+        // `mozjpeg` crate API to toggle it independently - the only two
+        // profiles the crate exposes are `JCP_MAX_COMPRESSION` and
+        // `JCP_FASTEST`). Trellis is real CPU, not free: `encode/jpeg_baseline`
+        // measured 9.61ms with it on vs 3.07ms for the old `image`-crate
+        // encoder it replaced (#76's own regression, ~3x, would fail this
+        // repo's 15% bench gate as-is).
+        //
+        // Measured on the Kodak True Color corpus (24 real photos, same
+        // corpus/DSSIM method as `adr/0003-webp-measurement.md`) whether
+        // that CPU actually buys smaller files at *matched* DSSIM (not
+        // matched nominal quality number - see that ADR for why nominal
+        // comparisons are invalid here): current `JCP_MAX_COMPRESSION`
+        // default is ~12% smaller than the old `image`-crate encoder
+        // (median ratio 0.881) but costs 3-8x its encode time. Dropping to
+        // `JCP_FASTEST` (this branch) is still ~5% smaller than the old
+        // `image`-crate encoder (median ratio 0.946) while being 3-4x
+        // *faster* than that encoder too (mozjpeg/libjpeg-turbo's SIMD C
+        // beats `image`'s pure-Rust baseline encoder even before mozjpeg's
+        // own extensions enter the picture) - a strict win on both axes
+        // over the pre-#76 baseline, and at the *same* nominal quality
+        // number `JCP_FASTEST` even scores a lower (better) mean DSSIM
+        // than the current `JCP_MAX_COMPRESSION` default (0.001787 vs
+        // 0.002236 at quality 75) - trellis trades some visual fidelity
+        // for extra size reduction at a fixed quality number, so removing
+        // it does not make default output worse, only smaller-but-less-so.
+        // Full measurement table in this change's own report.
+        //
+        // Progressive output (explicit `jpgo:progressive` request) keeps
+        // the full `JCP_MAX_COMPRESSION` profile below - progressive is
+        // already an opt-in, pay-for-what-you-use path, so its extra cost
+        // is the caller's choice, not a default everyone pays.
+        if !progressive {
+            compress.set_fastest_defaults();
+        }
+
         // 4:2:2 == `(2, 1)` for both Cb and Cr - this crate's pre-#76
         // default, matching `image::codecs::jpeg::JpegEncoder`'s hardcoded
         // subsampling exactly (see this function's own doc comment above).

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -883,28 +883,47 @@ impl ImageService {
 
                 buf.into_inner()
             }
+            // #76: routed through `Self::encode_jpeg` (mozjpeg/libjpeg-turbo)
+            // instead of `image::codecs::jpeg::JpegEncoder` so
+            // `jpeg_progressive`/`jpeg_no_subsampling` - and, via
+            // `encode_with_max_bytes`, `max_bytes` - actually reach the
+            // encoder; see `encode_jpeg`'s own doc comment for why
+            // `image`'s encoder can't do any of the three. `progressive`/
+            // `no_subsampling` each fall back to this deployment's
+            // configured default (`PerformanceConfig::jpeg_progressive_default`/
+            // `jpeg_no_subsampling_default`) when the request's own `jpgo:`
+            // segment doesn't say - both default `false`, reproducing
+            // exactly this crate's pre-#76 JPEG output when neither new
+            // option is used.
             ImageFormat::Jpeg => {
                 let quality = params
                     .jpeg_quality
                     .or(params.quality)
                     .unwrap_or(DEFAULT_JPEG_QUALITY);
+                let progressive = params
+                    .jpeg_progressive
+                    .unwrap_or(config.jpeg_progressive_default);
+                let no_subsampling = params
+                    .jpeg_no_subsampling
+                    .unwrap_or(config.jpeg_no_subsampling_default);
+                let icc_ref = icc_profile.as_deref();
 
-                let estimated_size = Self::estimate_output_size(&img, &output_format);
-                let mut buf = Cursor::new(Vec::with_capacity(estimated_size));
+                let result = match params.max_bytes {
+                    // `max_bytes` is only meaningful for JPEG here - see
+                    // `Self::MAX_BYTES_SEARCH_ATTEMPTS`'s doc comment for
+                    // the measured encode-cost reasoning behind not
+                    // offering it for AVIF (roughly two orders of
+                    // magnitude more expensive per encode), and PNG/GIF
+                    // have no continuous quality axis to search over at
+                    // all (`fq:png:N` is already rejected at parse time
+                    // for the same reason).
+                    Some(max_bytes) => Self::encode_with_max_bytes(max_bytes, quality, |q| {
+                        Self::encode_jpeg(&img, q, progressive, no_subsampling, icc_ref)
+                    }),
+                    None => Self::encode_jpeg(&img, quality, progressive, no_subsampling, icc_ref),
+                };
 
-                let mut encoder =
-                    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
-                if let Some(icc) = icc_profile {
-                    // Same best-effort reasoning as the PNG branch above:
-                    // `JpegEncoder::set_icc_profile` only fails for
-                    // genuinely unsupported encoders, never for
-                    // `JpegEncoder` itself.
-                    let _ = encoder.set_icc_profile(icc);
-                }
-                img.write_with_encoder(encoder)
-                    .context(format!("Failed to encode image to {:?}", output_format))?;
-
-                buf.into_inner()
+                result.context(format!("Failed to encode image to {:?}", output_format))?
             }
             ImageFormat::Avif => {
                 let quality = params.quality.unwrap_or(DEFAULT_AVIF_QUALITY);
@@ -1967,6 +1986,228 @@ impl ImageService {
         };
 
         Ok(memory.to_vec())
+    }
+
+    /// Encodes `img` to JPEG via `mozjpeg::Compress`/libjpeg-turbo instead
+    /// of `image::codecs::jpeg::JpegEncoder` (#76). The `image` crate's own
+    /// JPEG encoder has no progressive-mode switch and hardcodes 4:2:2
+    /// chroma subsampling - verified against its actual public API
+    /// (`image-0.25.10/src/codecs/jpeg/encoder.rs`: exactly `new`,
+    /// `new_with_quality`, `set_pixel_density`, `encode`, `encode_image`,
+    /// no subsampling or progressive-mode knob at all) - so neither
+    /// `progressive` nor `no_subsampling` below could be threaded through
+    /// it. `mozjpeg` was already a dependency (added for DCT-scaled decode,
+    /// #63 stage 2, see `mozjpeg_decode` below) and its `Compress` type
+    /// exposes both directly, so this is a matter of routing JPEG *encode*
+    /// through the same crate rather than adding a new dependency.
+    ///
+    /// `no_subsampling: false` (the default, imgproxy's `jpgo:` `no_subsample`
+    /// slot left unset) reproduces 4:2:2 -
+    /// `set_chroma_sampling_pixel_sizes((2, 1), (2, 1))`, matching exactly
+    /// what `image`'s encoder always did - so a request that never touches
+    /// `jpgo:` gets byte-shape-equivalent chroma handling to before #76,
+    /// satisfying this issue's own "existing behaviour must not change
+    /// when unset" requirement. `no_subsampling: true` selects 4:4:4
+    /// (`(1, 1), (1, 1)`) - full chroma resolution, imgproxy's
+    /// `IMGPROXY_JPEG_NO_SUBSAMPLING`.
+    ///
+    /// `pub` (like `encode_webp` above) so `benches/encode.rs` can
+    /// benchmark the exact path production uses.
+    ///
+    /// Wrapped in `catch_unwind`, same reasoning as `mozjpeg_decode` below:
+    /// mozjpeg's error manager unwinds (panics) on a libjpeg-level error
+    /// rather than returning one, so a real encode failure must be caught
+    /// here instead of taking the whole worker thread down. `AssertUnwindSafe`
+    /// is sound for the same reason it is in `mozjpeg_decode`: every
+    /// captured value (`rgb`, `icc_owned`, the `Copy` scalars) is either
+    /// freshly-owned local data or `Copy`, none of it shared/interior-mutable
+    /// state that could be left torn by an unwind.
+    pub fn encode_jpeg(
+        img: &DynamicImage,
+        quality: u8,
+        progressive: bool,
+        no_subsampling: bool,
+        icc_profile: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        let rgb = img.to_rgb8();
+        let icc_owned = icc_profile.map(<[u8]>::to_vec);
+
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Self::encode_jpeg_inner(&rgb, quality, progressive, no_subsampling, icc_owned.as_deref())
+        }))
+        .unwrap_or_else(|payload| {
+            let msg = payload
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_string()))
+                .unwrap_or_else(|| "mozjpeg panicked with a non-string payload".to_string());
+            Err(anyhow::anyhow!("mozjpeg encode panicked: {msg}"))
+        })
+    }
+
+    fn encode_jpeg_inner(
+        rgb: &RgbImage,
+        quality: u8,
+        progressive: bool,
+        no_subsampling: bool,
+        icc_profile: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        let (width, height) = rgb.dimensions();
+
+        let mut compress = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        compress.set_size(width as usize, height as usize);
+
+        // 4:2:2 == `(2, 1)` for both Cb and Cr - this crate's pre-#76
+        // default, matching `image::codecs::jpeg::JpegEncoder`'s hardcoded
+        // subsampling exactly (see this function's own doc comment above).
+        // 4:4:4 == `(1, 1)` - full chroma resolution. Set before
+        // `set_progressive_mode` below so mozjpeg's default progressive
+        // scan script (`jpeg_simple_progression`) is built against the
+        // sampling factors actually in effect, not libjpeg's own defaults.
+        let subsampling_px_size = if no_subsampling { (1, 1) } else { (2, 1) };
+        compress.set_chroma_sampling_pixel_sizes(subsampling_px_size, subsampling_px_size);
+
+        compress.set_quality(f32::from(quality));
+
+        // mozjpeg's own default (`Compress::new`'s `jpeg_set_defaults`,
+        // under its default `JCP_MAX_COMPRESSION` compress profile)
+        // already builds and installs a progressive scan script - real
+        // MozJPEG's whole "smaller by default" premise, confirmed against
+        // `mozjpeg-sys-2.2.3/vendor/jcparam.c`'s `jpeg_set_defaults`: it
+        // sets `master->optimize_scans = TRUE` and calls
+        // `jpeg_simple_progression(cinfo)` unconditionally at construction
+        // time. So an *unset* `progressive` here must actively opt back
+        // *out* of that default to reproduce this crate's pre-#76 baseline
+        // (non-progressive) output - it is not, as `set_progressive_mode`'s
+        // own "you can only turn it on" doc comment might suggest, already
+        // the starting point. `set_optimize_scans(false)` is what
+        // `jcmaster.c`'s `jinit_c_master_control` actually keys off of at
+        // `start_compress` time (`cinfo->master->optimize_scans` forces
+        // `progressive_mode = TRUE` in `validate_script` regardless of
+        // `scan_info`'s contents) - and, on the `false` path, also nulls
+        // `cinfo->scan_info`, which `jinit_c_master_control` separately
+        // checks (`scan_info == NULL` -> `progressive_mode = FALSE,
+        // num_scans = 1`) - so `set_optimize_scans(false)` is the one call
+        // that actually forces real baseline sequential. Verified
+        // empirically against this exact mozjpeg version: without it, a
+        // "baseline" and a "progressive" encode of the same pixels at the
+        // same quality produced byte-identical output (both already
+        // progressive) - this is not merely a doc-derived belief.
+        if progressive {
+            compress.set_progressive_mode();
+        } else {
+            compress.set_optimize_scans(false);
+        }
+
+        let estimated_size = (width as usize).saturating_mul(height as usize) / 2;
+        let mut started = compress
+            .start_compress(Vec::with_capacity(estimated_size))
+            .context("mozjpeg: failed to start compression")?;
+
+        if let Some(icc) = icc_profile.filter(|icc| !icc.is_empty()) {
+            // Same best-effort spirit as the PNG/pre-#76 JPEG branches'
+            // `set_icc_profile` calls elsewhere in this file: a source ICC
+            // profile is a colour-fidelity nicety, not something worth
+            // failing the whole request over. `write_icc_profile` itself
+            // has no fallible return (any failure surfaces as a libjpeg
+            // error caught by this function's `catch_unwind` wrapper), so
+            // there's nothing to ignore here beyond the empty-profile
+            // guard above (`write_icc_profile` panics on empty input).
+            started.write_icc_profile(icc);
+        }
+
+        started
+            .write_scanlines(rgb.as_raw())
+            .context("mozjpeg: failed to write scanlines")?;
+
+        started
+            .finish()
+            .context("mozjpeg: failed to finish compression")
+    }
+
+    /// Maximum number of extra encode attempts `encode_with_max_bytes`'s
+    /// quality search performs beyond the caller's own first choice of
+    /// quality (#76, imgproxy's `max_bytes`/`mb:{bytes}`). Bounds real,
+    /// measured encode cost - `benches/encode.rs`'s `jpeg_baseline`/
+    /// `jpeg_progressive` benchmarks put a single JPEG encode at a few
+    /// milliseconds for a resized (post-pipeline) image, so a handful of
+    /// extra full encodes per request is a small, predictable tax. This is
+    /// exactly why `max_bytes` is only wired up for JPEG output below
+    /// (`encode_single_image`'s JPEG branch) and not, say, AVIF: AVIF
+    /// encoding is roughly two orders of magnitude more expensive per the
+    /// `ravif`/AVIF measurements in `adr/0001-image-engine.md` (150-300ms
+    /// per encode at typical quality/speed settings), so even this same
+    /// small attempt cap would turn one request into a multi-second tail
+    /// latency spike - a cost this crate has no way to hide from the
+    /// caller. A binary search over the `1..=255` `u8` quality range
+    /// converges in at most 8 comparisons; capping at 6 trades the last
+    /// step or two of precision (the resulting quality can land within a
+    /// few units of the tightest possible fit) for a firm, small upper
+    /// bound on total request cost.
+    const MAX_BYTES_SEARCH_ATTEMPTS: u32 = 6;
+
+    /// Iteratively lowers `encode_at`'s quality argument via binary search
+    /// until the encoded output is at or under `max_bytes`, or
+    /// [`Self::MAX_BYTES_SEARCH_ATTEMPTS`] is exhausted (#76, imgproxy's
+    /// `max_bytes`/`mb:{bytes}`). Mirrors imgproxy's own documented
+    /// best-effort behaviour ("automatically degrades the quality... until
+    /// the image size is under the specified amount of bytes") - including
+    /// what happens when even the lowest quality tried doesn't fit: the
+    /// smallest output found across every attempt is returned rather than
+    /// erroring the request out, since an unreachable byte budget is a
+    /// caller configuration choice, not a failure this crate can recover
+    /// from by trying harder.
+    ///
+    /// `initial_quality` is both the search's upper bound and the quality
+    /// tried first (the caller's originally-requested quality, `q:`/`fq:`
+    /// resolved) - if it already fits, this returns after that single
+    /// encode with no extra attempts spent, so a `max_bytes` budget that's
+    /// already satisfied by the ordinary request costs nothing extra.
+    fn encode_with_max_bytes(
+        max_bytes: u64,
+        initial_quality: u8,
+        mut encode_at: impl FnMut(u8) -> Result<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
+        let first = encode_at(initial_quality)?;
+        if first.len() as u64 <= max_bytes || initial_quality <= 1 {
+            return Ok(first);
+        }
+
+        let mut best = first;
+        let mut low: u8 = 1;
+        let mut high: u8 = initial_quality - 1;
+
+        for _ in 0..Self::MAX_BYTES_SEARCH_ATTEMPTS {
+            if low > high {
+                break;
+            }
+            let mid = low + (high - low) / 2;
+            let candidate = encode_at(mid)?;
+
+            if candidate.len() as u64 <= max_bytes {
+                // Fits within budget - remember it (a higher quality is
+                // always preferred among fitting candidates) and try a
+                // higher quality next to see if it still fits.
+                best = candidate;
+                if mid == u8::MAX {
+                    break;
+                }
+                low = mid + 1;
+            } else {
+                // Doesn't fit - if nothing has fit yet, keep whichever
+                // over-budget candidate is smallest as the best-effort
+                // fallback; either way, try a lower quality next.
+                if best.len() as u64 > max_bytes && candidate.len() < best.len() {
+                    best = candidate;
+                }
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            }
+        }
+
+        Ok(best)
     }
 
     /// Rejects a request whose requested output width/height exceed the
@@ -4315,6 +4556,270 @@ mod tests {
              ({} bytes), producing larger output",
             out_override.len(),
             out_global.len()
+        );
+    }
+
+    // ---- #76: progressive JPEG, chroma subsampling, max_bytes ----
+
+    /// `jpgo:1` (progressive) must actually change the encoded bytes, not
+    /// silently no-op - a flag that parses but does nothing is worse than
+    /// no flag at all. Direction (smaller/larger) is measured separately in
+    /// `benches/encode.rs` against the real corpus rather than asserted
+    /// here, since the issue's "typically 2-10% smaller" claim needed
+    /// verifying, not assuming.
+    #[test]
+    fn jpeg_progressive_option_produces_different_bytes_than_baseline() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let baseline = ResizeQuery {
+            jpeg_progressive: Some(false),
+            ..base.clone()
+        };
+        let progressive = ResizeQuery {
+            jpeg_progressive: Some(true),
+            ..base
+        };
+
+        let (out_baseline, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &baseline, &config)
+                .expect("processing should succeed");
+        let (out_progressive, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &progressive, &config)
+                .expect("processing should succeed");
+
+        assert_ne!(
+            out_baseline, out_progressive,
+            "jpgo:1 must produce different encoded bytes than the baseline default"
+        );
+
+        // Both must still decode to the same pixel dimensions - progressive
+        // is a scan-structure change, not a resize.
+        let dims_baseline = image::load_from_memory_with_format(&out_baseline, ImageFormat::Jpeg)
+            .expect("baseline output should decode")
+            .dimensions();
+        let dims_progressive =
+            image::load_from_memory_with_format(&out_progressive, ImageFormat::Jpeg)
+                .expect("progressive output should decode")
+                .dimensions();
+        assert_eq!(dims_baseline, dims_progressive);
+    }
+
+    /// An unset `jpeg_progressive` (the common case) must resolve through
+    /// `PerformanceConfig::jpeg_progressive_default` and produce output
+    /// byte-identical to explicitly requesting the same default - proving
+    /// the deployment-default resolution in `encode_single_image`'s JPEG
+    /// branch is actually wired up, not just present in the struct.
+    #[test]
+    fn jpeg_progressive_unset_resolves_to_deployment_default() {
+        let bytes = fixtures::photo_like();
+        let config = PerformanceConfig::default(); // jpeg_progressive_default: false
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let unset = ResizeQuery {
+            jpeg_progressive: None,
+            ..base.clone()
+        };
+        let explicit_false = ResizeQuery {
+            jpeg_progressive: Some(false),
+            ..base
+        };
+
+        let (out_unset, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &unset, &config)
+                .expect("processing should succeed");
+        let (out_explicit, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &explicit_false, &config)
+                .expect("processing should succeed");
+
+        assert_eq!(
+            out_unset, out_explicit,
+            "unset jpeg_progressive must resolve to the same output as the deployment default"
+        );
+    }
+
+    /// `jpgo:1:1` (no_subsampling, 4:4:4) must actually change the encoded
+    /// bytes relative to this crate's 4:2:2 default, and - unlike
+    /// progressive, whose size effect is corpus-dependent - retaining full
+    /// chroma resolution can only ever cost the same or more bytes than
+    /// throwing chroma detail away, for the same quality/content, so
+    /// asserting the direction here (unlike progressive) is safe.
+    #[test]
+    fn jpeg_no_subsampling_produces_different_and_larger_output() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let subsampled = ResizeQuery {
+            jpeg_no_subsampling: Some(false),
+            ..base.clone()
+        };
+        let full_chroma = ResizeQuery {
+            jpeg_no_subsampling: Some(true),
+            ..base
+        };
+
+        let (out_subsampled, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &subsampled, &config)
+                .expect("processing should succeed");
+        let (out_full_chroma, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &full_chroma, &config)
+                .expect("processing should succeed");
+
+        assert_ne!(out_subsampled, out_full_chroma);
+        assert!(
+            out_full_chroma.len() >= out_subsampled.len(),
+            "4:4:4 ({} bytes) should never be smaller than 4:2:2 ({} bytes) for the same \
+             quality/content",
+            out_full_chroma.len(),
+            out_subsampled.len()
+        );
+    }
+
+    /// `mb:{bytes}` must actually cap the encoded output - a real photo
+    /// requested at a byte budget well under its default-quality size must
+    /// come back under (or very close to) that budget, not simply ignore
+    /// it. `encode_with_max_bytes`'s binary search can, in principle, not
+    /// land exactly at the budget (best-effort, bounded attempts), so this
+    /// asserts against a generous multiple of the budget rather than the
+    /// exact number - still tight enough to catch a no-op implementation.
+    #[test]
+    fn max_bytes_caps_jpeg_output_size() {
+        let bytes = fixtures::photo_like(); // 1920x1080
+        let config = PerformanceConfig::default();
+        let unrestricted = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let (unrestricted_output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &unrestricted, &config)
+                .expect("processing should succeed");
+
+        let budget = (unrestricted_output.len() / 4) as u64;
+        let capped = ResizeQuery {
+            max_bytes: Some(budget),
+            ..unrestricted
+        };
+
+        let (capped_output, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &capped, &config)
+                .expect("processing should succeed");
+
+        assert!(
+            capped_output.len() < unrestricted_output.len(),
+            "max_bytes must actually lower quality and shrink output: capped {} bytes vs \
+             unrestricted {} bytes",
+            capped_output.len(),
+            unrestricted_output.len()
+        );
+        assert!(
+            (capped_output.len() as u64) <= budget * 2,
+            "expected the max_bytes search to land reasonably close to the {budget}-byte \
+             budget, got {} bytes",
+            capped_output.len()
+        );
+    }
+
+    /// `mb:0` (parsed to `None` at the URL layer, #76's "0 means unset"
+    /// convention) must behave exactly like `max_bytes` never being set at
+    /// all - no search, no output-size change.
+    #[test]
+    fn max_bytes_none_does_not_change_output() {
+        let bytes = fixtures::photo_like();
+        let config = PerformanceConfig::default();
+        let base = ResizeQuery {
+            format: ApiImageFormat::Jpg,
+            ..query(Some(400), Some(300))
+        };
+
+        let (out_default, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &base, &config)
+                .expect("processing should succeed");
+
+        let explicit_none = ResizeQuery {
+            max_bytes: None,
+            ..base
+        };
+        let (out_explicit_none, _) =
+            ImageService::process_image_blocking_with_limits(&bytes, &explicit_none, &config)
+                .expect("processing should succeed");
+
+        assert_eq!(out_default, out_explicit_none);
+    }
+
+    /// Unit-level test of the search itself (`encode_with_max_bytes`),
+    /// isolated from JPEG encoding: a synthetic "encoder" whose output size
+    /// is just its quality argument lets the search's convergence and
+    /// attempt-bounding be asserted precisely, including the "budget
+    /// already satisfied by the first attempt costs nothing extra" and
+    /// "budget unreachable even at the lowest quality" edge cases imgproxy
+    /// itself documents (best-effort, not an error).
+    #[test]
+    fn encode_with_max_bytes_converges_within_the_attempt_bound() {
+        use std::cell::Cell;
+
+        let attempts = Cell::new(0u32);
+        let encode_at = |quality: u8| -> Result<Vec<u8>> {
+            attempts.set(attempts.get() + 1);
+            Ok(vec![0u8; quality as usize])
+        };
+
+        let result = ImageService::encode_with_max_bytes(50, 100, encode_at).unwrap();
+        assert!(
+            result.len() as u64 <= 50,
+            "expected the search to land at or under the 50-byte budget, got {} bytes",
+            result.len()
+        );
+        // 1 initial attempt + at most `MAX_BYTES_SEARCH_ATTEMPTS` more.
+        assert!(
+            attempts.get() <= 1 + ImageService::MAX_BYTES_SEARCH_ATTEMPTS,
+            "expected at most {} total encode attempts, got {}",
+            1 + ImageService::MAX_BYTES_SEARCH_ATTEMPTS,
+            attempts.get()
+        );
+    }
+
+    /// A budget already satisfied by the caller's own requested quality
+    /// must cost exactly one encode attempt - no search needed.
+    #[test]
+    fn encode_with_max_bytes_already_satisfied_costs_one_attempt() {
+        use std::cell::Cell;
+
+        let attempts = Cell::new(0u32);
+        let encode_at = |quality: u8| -> Result<Vec<u8>> {
+            attempts.set(attempts.get() + 1);
+            Ok(vec![0u8; quality as usize])
+        };
+
+        let result = ImageService::encode_with_max_bytes(1000, 50, encode_at).unwrap();
+        assert_eq!(result.len(), 50);
+        assert_eq!(attempts.get(), 1);
+    }
+
+    /// A budget unreachable even at the lowest quality (`1`) must still
+    /// return the smallest output found (best-effort), not an error -
+    /// matching imgproxy's own documented behaviour.
+    #[test]
+    fn encode_with_max_bytes_unreachable_budget_returns_smallest_found() {
+        let encode_at = |quality: u8| -> Result<Vec<u8>> { Ok(vec![0u8; quality as usize]) };
+
+        let result = ImageService::encode_with_max_bytes(0, 100, encode_at).unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "expected the search to bottom out at quality=1 (smallest possible) when the \
+             budget is unreachable"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #76. Adds progressive JPEG, chroma-subsampling control and `max_bytes` — and, in doing so, makes JPEG encoding **3.2× faster** than before while producing **5% smaller** files.

| Bench | main | this PR |
|---|---:|---:|
| `encode/jpeg` | 3.07 ms | **0.95 ms** |
| `pipeline photo_like → thumbnail_jpg` | 6.32 ms | **6.03 ms** |

## Intent

`image::codecs::jpeg::JpegEncoder` cannot express either option — its entire public API is `new`, `new_with_quality`, `set_pixel_density`, `encode`, `encode_image`, with 4:2:2 hardcoded (verified in the vendored source). JPEG encoding therefore moves to `mozjpeg::Compress`, already a dependency since #63 stage 2, so **no new dependency**.

## Scope

- `jpgo:{progressive}:{no_subsample}` — imgproxy's `jpeg_options`/`jpgo`; the first two of its six slots, matching the partial-implementation precedent already set by this codebase's `webpo`.
- `mb:{bytes}` — imgproxy's `max_bytes`. **Bounded** binary search, `MAX_BYTES_SEARCH_ATTEMPTS = 6`, **JPEG only**. Each attempt is a full encode; at WebP's ~30 ms and AVIF's ~368 ms median (`adr/0004`) an unbounded search would be a self-inflicted DoS. PNG and GIF have no continuous quality knob.
- `JPEG_PROGRESSIVE` / `JPEG_NO_SUBSAMPLING` deployment defaults.
- `CACHE_KEY_VERSION` 8 → 9, bumped once by the integrator rather than per-change.

## Two findings worth reading

### 1. mozjpeg already defaults to progressive — the feature initially did nothing

`jpeg_set_defaults` calls `jpeg_simple_progression` unconditionally under its default profile, so the first implementation produced **byte-identical output for progressive and baseline**. A feature that looked wired up and wasn't.

The crate's own `set_progressive_mode` doc comment ("you can only turn it on") actively misleads here. The fix is `set_optimize_scans(false)`, which is what `jcmaster.c`'s `jinit_c_master_control` actually keys off — it nulls `scan_info` and clears the `optimize_scans` flag that otherwise forces `progressive_mode = TRUE` regardless. Traced through vendored `jcparam.c`/`jcmaster.c` and confirmed empirically, not inferred from docs.

### 2. The obvious mozjpeg default would have shipped a 16% regression

`Compress::new` selects `JCP_MAX_COMPRESSION`, whose `jpeg_set_defaults` sets `trellis_quant = (compress_profile == JCP_MAX_COMPRESSION)` — independent of the progressive toggle, so even non-progressive encodes paid full trellis cost:

- `encode/jpeg` 3.07 → 9.61 ms
- `pipeline → thumbnail_jpg` 6.32 → 7.35 ms, **+16%**, which fails the regression gate

Measured on the Kodak corpus at DSSIM-matched quality (`adr/0003`'s method):

| Encoder | Size | Time | Mean DSSIM @ nominal q75 |
|---|---:|---:|---:|
| `image` crate (pre-#76) | 1.00× | 1.00× | 0.001678 |
| mozjpeg `JCP_MAX_COMPRESSION` | 0.88× | 3–8× slower | 0.002236 |
| **mozjpeg `JCP_FASTEST`** (shipped) | **0.95×** | **3–4× faster** | **0.001787** |

`JCP_FASTEST` beats the old encoder on size *and* speed simultaneously, and scores **better** DSSIM than max-compression at the same nominal quality — trellis trades fidelity for size at a fixed quality knob, so dropping it does not make output worse. The extra ~7 points of compression was not worth 3–8× CPU on every request. Explicitly-requested progressive output still gets the full profile, because that cost is opted into.

"mozjpeg compresses better than libjpeg" is true and was still the wrong default. Recorded in `.bench-baseline/BASELINE.md` as a fourth entry in that file's running list of measurement traps.

### The issue's own claim, checked

"Progressive is typically 2–10% smaller" **held up**: 1.7–12% on photo-like content across q50/75/90, and ~48% on a flat/solid-colour fixture.

## Verification

```
cargo test --no-default-features --features local_fs    675 passed, 0 failed
cargo test --no-default-features --features s3          663 passed, 0 failed
cargo clippy --no-default-features --features local_fs --all-targets   0 errors
python3 .github/scripts/check_env_docs.py               exit 0
```

Benchmarks re-run by the orchestrator, not taken on report. Every new option is hashed into the cache key, and the tests assert the encoded **bytes** differ — a flag that silently does nothing is worse than no flag, as finding 1 demonstrates.

## Risk Assessment

- **Every JPEG this service produces changes bytes**, including requests using no new option. Perceptually equivalent — measured, not assumed — but not byte-identical. This is the second, independent reason for the v9 cache-key bump: a v8 entry would otherwise keep being served from the old encoder indefinitely.
- 4:2:2 remains the default, matching `image`'s hardcoded behaviour exactly, so unset output is unchanged in character.
- `max_bytes` is JPEG-only. imgproxy also applies it to WebP; that is deliberately not matched here on cost grounds, and is a real, stated parity gap.
- `encode/jpeg` in the new baseline table is `encode/jpeg_baseline`, renamed when the variants were added — noted so it is not mistaken for a like-for-like row against older tables.

## Reviewer Focus

1. `encode_jpeg_inner` in `src/services/image/handler.rs` — the `set_fastest_defaults()` placement specifically. It re-runs `jpeg_set_defaults` internally and would clobber quality and sampling factors if called after them.
2. The `max_bytes` attempt bound, and whether 6 is right.
3. The v9 cache-key bump — whether the encoder change alone justifies it independently of the three new fields.

## AI Usage Declaration

AI (Claude Opus 5 orchestrating Sonnet sub-agents) implemented and measured this. The +16% regression was **not** in the implementing agent's report — the orchestrator found it by running the pipeline benchmark before accepting the work, and commissioned the cost/benefit measurement that produced the `JCP_FASTEST` decision. All final numbers were re-run by the orchestrator.

- [x] A human is accountable for this change.
- [x] Verified against real build, test and benchmark output.
- [x] The byte-level output change and the `max_bytes` parity gap are stated rather than omitted.
