### PR TITLE
perf: route full-size JPEG decode through mozjpeg (#67)

### DIFF
--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -1,27 +1,45 @@
 //! Decode-stage benchmarks: JPEG / PNG / WebP at a few resolutions.
 //!
-//! This calls `image::load_from_memory_with_format`, the exact call
-//! `ImageService::process_image_blocking` (src/services/image/handler.rs)
-//! makes once it has picked a format hint - i.e. this measures the real
-//! decode cost the service pays, not a synthetic stand-in.
+//! PNG and WebP call `image::load_from_memory_with_format`, the exact call
+//! `ImageService::decode_with_image_crate` (src/services/image/handler.rs)
+//! makes for those formats - i.e. this measures the real decode cost the
+//! service pays, not a synthetic stand-in.
+//!
+//! JPEG instead calls `ImageService::mozjpeg_decode(&bytes, 8)` (#67):
+//! every JPEG decode, DCT-scaled or not, now goes through mozjpeg rather
+//! than `image`-crate/zune-jpeg - see that function's own doc comment and
+//! `decode_jpeg_scaled`'s retired-rationale comment for why. `scale_num =
+//! 8` is "no DCT reduction," matching this bench's full-size decode (no
+//! resize is requested here), the same call `decode_jpeg_scaled` makes when
+//! `select_jpeg_dct_scale` picks no scaling.
 
 #[path = "fixtures.rs"]
 mod fixtures;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use emgr::services::image::handler::ImageService;
 use image::ImageFormat;
 
 const SIZES: [(u32, u32); 3] = [(640, 360), (1280, 720), (1920, 1080)];
-const FORMATS: [(&str, ImageFormat); 3] = [
-    ("jpeg", ImageFormat::Jpeg),
-    ("png", ImageFormat::Png),
-    ("webp", ImageFormat::WebP),
-];
+const NON_JPEG_FORMATS: [(&str, ImageFormat); 2] =
+    [("png", ImageFormat::Png), ("webp", ImageFormat::WebP)];
 
 fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("decode");
 
-    for (fmt_name, format) in FORMATS {
+    for (w, h) in SIZES {
+        let bytes = fixtures::photo_like_sized(w, h, ImageFormat::Jpeg);
+        group.throughput(Throughput::Bytes(bytes.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("jpeg", format!("{w}x{h}")),
+            &bytes,
+            |b, bytes| {
+                b.iter(|| ImageService::mozjpeg_decode(bytes, 8).expect("decode fixture"));
+            },
+        );
+    }
+
+    for (fmt_name, format) in NON_JPEG_FORMATS {
         for (w, h) in SIZES {
             let bytes = fixtures::photo_like_sized(w, h, format);
             group.throughput(Throughput::Bytes(bytes.len() as u64));

--- a/src/services/cache/handler.rs
+++ b/src/services/cache/handler.rs
@@ -86,6 +86,30 @@ use sha2::{Digest, Sha256};
 /// the second, independent reason this bump is required rather than merely
 /// tidy: without it, existing entries would keep being served from the old
 /// encoder indefinitely.
+/// **Deliberately NOT bumped for #67** (full-size JPEG decode routed
+/// through mozjpeg instead of zune-jpeg). That change does alter output
+/// bytes for every non-downscaling JPEG request, which is the same
+/// property that justified half of the v9 bump - so the omission is a
+/// decision, not an oversight, and the reasoning is recorded here rather
+/// than left for someone to re-derive:
+///
+/// - It adds no new hashed field, so there is no collision hazard. Nothing
+///   can be served the wrong image; the only effect is that an entry
+///   cached before the change holds bytes from the previous decoder.
+/// - Those bytes are perceptually identical, measured rather than assumed:
+///   DSSIM <= 0.000014 across 36 real-photo fixtures, max per-channel
+///   difference 3/255 - the same order as the `fast_image_resize` kernel
+///   swap this project already accepted as imperceptible.
+/// - A bump invalidates *every* cached entry in *every* format, forcing a
+///   full reprocessing storm on the next request for each. With AVIF
+///   encode measured up to 986 ms (`adr/0004`), that cost is real and
+///   falls entirely on the cold path this project is already 3.65x behind
+///   imgproxy on.
+///
+/// Flushing the whole cache to correct an invisible rounding difference is
+/// a worse trade than letting old entries age out naturally. If a future
+/// change to this path is *perceptible*, that calculus flips and it should
+/// bump.
 const CACHE_KEY_VERSION: u8 = 9;
 
 #[derive(Clone, Builder)]

--- a/src/services/image/handler.rs
+++ b/src/services/image/handler.rs
@@ -2709,12 +2709,16 @@ impl ImageService {
     }
 
     /// Decodes `image_bytes`, enforcing every guard `decode_with_image_crate`
-    /// carries, with one addition (#63 stage 2): for JPEG, tries a DCT-scaled
-    /// decode through mozjpeg/libjpeg-turbo first, which can decode directly
-    /// at a fraction of the source resolution instead of always decoding
-    /// full-size and discarding most of the data during resize - see
-    /// `decode_jpeg_scaled`'s doc comment for the measured win. PNG and WebP
-    /// are untouched, always going straight to `decode_with_image_crate`.
+    /// carries, with one addition (#63 stage 2, extended by #67): for JPEG,
+    /// tries a decode through mozjpeg/libjpeg-turbo first - DCT-scaled when
+    /// a resize makes a smaller decode safe (decoding directly at a
+    /// fraction of the source resolution instead of always decoding
+    /// full-size and discarding most of the data during resize), full-size
+    /// otherwise. #67 measured mozjpeg's full-size decode ~1.5x faster than
+    /// the `image`-crate/zune-jpeg path too, not just the scaled case #63
+    /// stage 2 covered - see `decode_jpeg_scaled`'s doc comment for the
+    /// measured win either way. PNG and WebP are untouched, always going
+    /// straight to `decode_with_image_crate`.
     ///
     /// If the mozjpeg path fails for any reason - including a caught panic,
     /// see `mozjpeg_decode` - this falls back to `decode_with_image_crate`
@@ -2817,16 +2821,14 @@ impl ImageService {
     ///   repeated here.)
     /// - #33's EXIF orientation and ICC profile are read off it too.
     ///
-    /// If `select_jpeg_dct_scale` decides no DCT reduction is safe/useful
-    /// for this request (`scale_num == 8`), this decoder is then reused
-    /// directly for the actual pixel decode - the exact same
-    /// `image::DynamicImage::from_decoder` call `decode_with_image_crate`
-    /// makes - rather than opening mozjpeg for zero benefit and risking a
-    /// gratuitous pixel-value difference from a second decoder's rounding.
-    /// Only when a real DCT scale is chosen does this drop the `image`-crate
-    /// decoder and hand off to mozjpeg. See `select_jpeg_dct_scale` for how
-    /// the scale factor itself is chosen - the "never decode smaller than
-    /// the target" requirement lives there.
+    /// Every JPEG decode - DCT-scaled or not - hands off to mozjpeg for the
+    /// actual pixel decode (#67): `scale_num == 8` just means
+    /// `mozjpeg_decode` is called with no DCT reduction, rather than the
+    /// `image`-crate/zune-jpeg decoder being reused for that case as it was
+    /// before #67. See the retired-rationale comment at the `drop(decoder)`
+    /// call site below for why, and `select_jpeg_dct_scale` for how the
+    /// scale factor itself is chosen - the "never decode smaller than the
+    /// target" requirement lives there.
     fn decode_jpeg_scaled(
         image_bytes: &[u8],
         max_src_resolution_mp: u64,
@@ -2910,22 +2912,43 @@ impl ImageService {
             raw_target_height,
         );
 
-        // `scale_num == 8` means no DCT reduction is safe/useful for this
-        // request (either no resize was requested at all, or the requested
-        // output is close enough to source resolution that even the
-        // gentlest 1/2 scale would decode below target) - mozjpeg would buy
-        // nothing here, so decode through the already-open `image`-crate
-        // decoder instead of opening a second decoder over the same bytes.
-        // This also keeps output byte-for-byte identical to
-        // `decode_with_image_crate` for every request that isn't actually
-        // downscaling, rather than introducing a second JPEG decoder's
-        // slightly different IDCT/chroma-upsampling rounding into a path
-        // that was never going to benefit from mozjpeg anyway.
-        if scale_num == 8 {
-            let img =
-                image::DynamicImage::from_decoder(decoder).context("Failed to decode image")?;
-            return Ok((img, orientation, icc_profile));
-        }
+        // RETIRED (#67), keeping the history because the reasoning was
+        // real, not a mistake: this used to special-case `scale_num == 8`
+        // (no DCT reduction is safe/useful for this request - either no
+        // resize was requested at all, or the requested output is close
+        // enough to source resolution that even the gentlest 1/2 scale
+        // would decode below target) by reusing the already-open
+        // `image`-crate decoder instead of opening mozjpeg, on the theory
+        // that mozjpeg would buy nothing for a full-size decode and that
+        // doing so kept output byte-for-byte identical to
+        // `decode_with_image_crate` rather than introducing a second JPEG
+        // decoder's rounding into a path that was never going to benefit.
+        //
+        // Both premises turned out wrong once actually measured (#67, not
+        // assumed): `image` 0.25.10 pulled in `zune-jpeg` 0.5.x, whose
+        // generic `ZByteReaderTrait` redesign made the per-byte
+        // end-of-stream check in its Huffman bit-refill loop fallible
+        // (`reader.eof()?`) where 0.4.x's was an infallible, immutable
+        // `bool` - a real cost paid on every byte of entropy-coded data,
+        // even for zune-jpeg's own in-memory reader. Measured on 36 real
+        // photographs (24-image Kodak corpus + 3 picsum.photos sources x 4
+        // resolutions, 640x360 through 3840x2160 - not the synthetic
+        // gradient-plus-noise fixture `benches/fixtures.rs` uses elsewhere,
+        // per the same reasoning `adr/0003`/`adr/0004` document), mozjpeg's
+        // full-size (`scale(8)`) decode is consistently ~1.5x faster than
+        // the `image`-crate path across every resolution bucket - see this
+        // change's own report for the full table. "Byte-for-byte identical"
+        // was also never a real requirement, just a convenient side effect
+        // of the old code path: mozjpeg's IDCT/chroma-upsampling rounding
+        // differs from zune-jpeg's by at most 3/255 per channel across that
+        // same 36-photo corpus, DSSIM median 0.0000081 / max 0.0000140 -
+        // imperceptible by the same DSSIM bar this project already accepts
+        // elsewhere (the `fast_image_resize` kernel swap at
+        // 0.0000047-0.0000093 and the alpha-fringe fix at 0.0000035, both
+        // in `.bench-baseline/BASELINE.md`'s "Current baseline" section).
+        // Every JPEG decode now goes through the one decoder instead of two
+        // decoders whose selection depended on whether the request
+        // happened to downscale.
         drop(decoder);
 
         let img = Self::mozjpeg_decode(image_bytes, scale_num)?;
@@ -3056,7 +3079,12 @@ impl ImageService {
     /// process. `AssertUnwindSafe` is sound here: `image_bytes` is a shared
     /// `&[u8]` with no interior mutability to leave torn, and `scale_num` is
     /// `Copy`.
-    fn mozjpeg_decode(image_bytes: &[u8], scale_num: u8) -> Result<DynamicImage> {
+    ///
+    /// `pub` (like `encode_webp`/`encode_jpeg` above) so `benches/decode.rs`
+    /// can benchmark the exact path production uses for JPEG (#67) instead
+    /// of the raw `image::load_from_memory_with_format` call that used to
+    /// be representative but, after #67, only reflects PNG/WebP.
+    pub fn mozjpeg_decode(image_bytes: &[u8], scale_num: u8) -> Result<DynamicImage> {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             Self::mozjpeg_decode_inner(image_bytes, scale_num)
         }))
@@ -4877,10 +4905,23 @@ mod tests {
     }
 
     /// Lossless WebP (`webp_lossless: Some(true)`) must round-trip the
-    /// source pixels exactly - no resize/blur/grayscale filter applied, and
-    /// a source with no alpha channel so the #34/#60 flatten/normalise
-    /// stage is a no-op, isolating this to purely the encoder's own
-    /// lossless-ness.
+    /// pixels the pipeline actually decoded exactly - no resize/blur/
+    /// grayscale filter applied, and a source with no alpha channel so the
+    /// #34/#60 flatten/normalise stage is a no-op, isolating this to purely
+    /// the encoder's own lossless-ness.
+    ///
+    /// The reference decode must go through the same decoder the pipeline
+    /// uses for this request (#67): `query(None, None)` requests no
+    /// resize, so `decode_jpeg_scaled` picks `scale_num == 8` and decodes
+    /// through `mozjpeg_decode`, not `image::load_from_memory`'s
+    /// zune-jpeg path (that stopped being true once #67 retired the old
+    /// scale_num == 8 special case - see `decode_jpeg_scaled`'s
+    /// retired-rationale comment). The two decoders differ by up to 3/255
+    /// per channel on real photographs - imperceptible, but enough to trip
+    /// a byte-identity assertion if the reference decode used the *other*
+    /// decoder than the one the pipeline actually ran. This test cares
+    /// about the WebP encoder's losslessness, not about which JPEG decoder
+    /// is faster, so `original` is decoded the same way the pipeline does.
     #[test]
     fn webp_lossless_round_trips_byte_identical_pixels() {
         let bytes = fixtures::photo_like(); // 1920x1080, no alpha channel
@@ -4895,7 +4936,7 @@ mod tests {
             ImageService::process_image_blocking_with_limits(&bytes, &params, &config)
                 .expect("processing should succeed");
 
-        let original = image::load_from_memory(&bytes)
+        let original = ImageService::mozjpeg_decode(&bytes, 8)
             .expect("source should decode")
             .to_rgba8();
         let decoded = image::load_from_memory(&output)
@@ -4906,7 +4947,7 @@ mod tests {
         assert_eq!(
             decoded.as_raw(),
             original.as_raw(),
-            "lossless webp round-trip must be byte-identical to the source pixels"
+            "lossless webp round-trip must be byte-identical to the pixels the pipeline decoded"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #67. Routes full-size JPEG decode through mozjpeg instead of `zune-jpeg`, recovering most of the ~30% regression the `image` 0.25.6 → 0.25.10 dependency bump introduced.

**`decode/jpeg 1920x1080`: 8.75 ms → 7.16 ms, −17.9% (p = 0.00).**

## Intent

#63 stage 2 already used mozjpeg, but only when there was something to scale. At `src/services/image/handler.rs`, `scale_num == 8` — no resize requested, or output too close to source for even 1/2 to help — fell back to the `image` crate, and **those are exactly the requests #67 is about**. JPEG decode therefore depended on whether a request happened to downscale.

## The measurement came first

The hypothesis was untested, and this project has been wrong five times about exactly this kind of plausible assumption — including about mozjpeg's own default profile, which turned out 3–8× *slower* until measured. So nothing was implemented until the numbers existed.

24-image Kodak corpus plus 3 picsum sources at 640×360 / 1280×720 / 1920×1080 / 3840×2160 — 36 real-photo fixtures, all re-encoded through the same baseline encoder so only content and resolution vary. 200 interleaved iterations per fixture, two independent full runs.

| Resolution | `image` (zune-jpeg 0.5) | mozjpeg `scale(8)` | ratio |
|---|---:|---:|---:|
| 640×360 | 1.33 ms | 0.83 ms | 1.60× |
| Kodak 768×512 (n=24) | 2.0–2.2 ms | 1.33–1.46 ms | ~1.50× |
| 1280×720 | 4.6–4.8 ms | 2.9–3.1 ms | 1.56× |
| 1920×1080 | 9.8–10.0 ms | 6.4–6.5 ms | ~1.53× |
| 3840×2160 | 40.0–41.1 ms | 26.2–26.8 ms | ~1.52× |

Consistent across both runs, every resolution and every content type. This one is a genuine win rather than another piece of received wisdom.

## Retiring a deliberate decision, not deleting it

The old branch carried a comment explaining it kept output byte-identical to the pure-`image`-crate path, avoiding a second decoder's different IDCT and chroma-upsampling rounding. That property cannot survive this change, so it is **retired explicitly** — the comment is rewritten to state both original premises and why measurement disproved each, rather than removed.

Perceptual equivalence measured across all 36 fixtures: **DSSIM median 0.0000081, max 0.0000140, max per-channel difference 3/255.** That is the same order as the `fast_image_resize` kernel swap this project already accepted as imperceptible (0.0000047–0.0000093).

## Safety

Verified by the orchestrator directly, not taken on report — a decoder that bypassed the resolution cap would turn a performance fix into a decompression-bomb hole:

- **Resolution cap (#26) still enforced.** `peek_dimensions` + `check_source_resolution` run at `handler.rs:578-579`, **before** `decode_with_limits` and therefore before any decoder is chosen. The guard is header-only and decoder-independent, so routing `scale_num == 8` through mozjpeg introduces no new gap — it relies on the identical pre-existing check the already-shipped `scale_num ∈ {1,2,4}` path uses.
- **`catch_unwind` covers the new call site.** `mozjpeg_decode` wraps every call, and the existing `mozjpeg_decode_returns_err_instead_of_panicking_on_non_jpeg_bytes` test already exercises it with `scale_num = 8` specifically.
- **EXIF orientation and ICC unaffected** — both are read from the header-only `image` decoder before this branch. Confirmed by `all_eight_exif_orientations_render_upright`, which uses `query(None, None)` and so exercises exactly this path.

## Cache key: deliberately not bumped

Output bytes change for every non-downscaling JPEG request — the same property that justified half of the v9 bump for #76 — so the omission is recorded in `CACHE_KEY_VERSION`'s doc comment rather than left to look like an oversight:

- No new hashed field, so no collision hazard. Nothing can be served the wrong image; an old entry simply holds the previous decoder's bytes.
- Those bytes are perceptually identical (DSSIM ≤ 0.000014, ≤ 3/255).
- A bump invalidates **every** entry in **every** format, and with AVIF encode measured up to 986 ms (`adr/0004`) that storm lands squarely on the cold path this project is already 3.65× behind imgproxy on.

Flushing the whole cache to correct an invisible rounding difference is the worse trade. If a future change to this path is *perceptible*, that calculus flips.

**Correction to a claim made while preparing this:** it was asserted that #76 shipped without a cache-key bump. It did not — #76 bumped v8 → v9 in `39f242c`. The precedent argued from did not exist, so this decision rests on the trade-off above instead.

## Verification

```
cargo test --no-default-features --features local_fs   676 passed, 0 failed
cargo test --no-default-features --features s3         663 passed, 0 failed
cargo clippy --no-default-features --features local_fs --all-targets   0 errors

decode/jpeg 640x360     1.106 ms -> 0.815 ms   -24.8%  (p = 0.00)
decode/jpeg 1280x720    3.905 ms -> 3.198 ms   -18.3%  (p = 0.00)
decode/jpeg 1920x1080   8.750 ms -> 7.158 ms   -17.9%  (p = 0.00)
```

Benchmarks re-run by the orchestrator rather than accepted from the report.

One test changed, and not because it was wrong: `webp_lossless_round_trips_byte_identical_pixels` decoded its reference via `image::load_from_memory` while the pipeline now uses mozjpeg for the same no-resize request, so the ≤3/255 difference broke a byte-equality assertion. It now decodes the reference through the same decoder the pipeline actually uses, with a comment saying why.

## Risk Assessment

- **Pipeline benchmarks are unchanged** (`thumbnail_jpg` ~6.0 ms, `photo_4k` ~19.1 ms) because those already downscale and so already used mozjpeg. The win lands on passthrough and near-source-size requests, which the pipeline benches do not represent.
- `decode/jpeg 1920x1080` does not fully return to the pre-regression 6.78 ms — `benches/decode.rs` uses a synthetic fixture where the gain is smaller than on real photos.
- `image`'s `jpeg` feature and `zune-jpeg` **cannot** be dropped: the header-only `peek_dimensions` open still goes through `image::ImageReader`, and `decode_with_image_crate` remains the fallback when mozjpeg fails.
- `mozjpeg_decode` widened to `pub`, matching the existing `encode_webp`/`encode_jpeg` convention, so `benches/decode.rs` benchmarks the real production path rather than a now-stale `image::load_from_memory_with_format` call.

## Reviewer Focus

1. The retired byte-identity comment — whether the DSSIM evidence adequately replaces the property it gave up.
2. The cache-key non-bump. This is the judgement call most worth disagreeing with.
3. That the resolution cap genuinely precedes decoder selection (`handler.rs:578`).

## AI Usage Declaration

AI (Claude Opus 5 orchestrating a Sonnet sub-agent) measured and implemented this. The orchestrator independently re-ran the benchmarks, verified the resolution-cap ordering by reading the call sequence, and checked the cache-key precedent claim in git history — finding it false and deciding on the merits instead.

- [x] A human is accountable for this change.
- [x] Implementation was gated on measurement; an honest negative result was an accepted outcome.
- [x] The retired invariant, the cache-key decision and the unchanged pipeline numbers are all stated rather than omitted.
