### PR TITLE
docs: refresh every document against the code

### DIFF
--- a/PERFORMANCE_OPTIMIZATIONS.md
+++ b/PERFORMANCE_OPTIMIZATIONS.md
@@ -17,8 +17,17 @@ commands given.
 
 - **Connection pooling**: `reqwest::Client` reuses connections, with a
   configurable pool size per host (`connection_pool_size`, default 50).
-- **HTTP/2**: enabled by default (`enable_http2`); reqwest negotiates it via
-  ALPN when the origin supports it.
+- **HTTP/2**: configurable (`enable_http2`); reqwest negotiates it via ALPN
+  when the origin supports it. Note: `PerformanceConfig::default()` and the
+  `high_throughput`/`low_latency` presets all set this `true`, but the
+  plain (no `PERFORMANCE_PROFILE`) construction path actually used at
+  startup - `PerformanceConfig::from(&EnvConfig)`'s fallback branch,
+  `src/config/performance.rs` - defaults an unset `ENABLE_HTTP2` to
+  `false`, not `true`. A deployment that never sets `ENABLE_HTTP2` and
+  never sets `PERFORMANCE_PROFILE` therefore runs with HTTP/2 off, despite
+  every other default in this codebase agreeing on `true`. See
+  `docs/configuration/performance.md` for the same discrepancy documented
+  against the full settings table.
 - **Keep-alive / timeouts**: both configurable (`keep_alive_timeout`,
   `http_timeout`), applied per request via a client pinned to the
   already-validated `(host, addr)` pair (`ImageService::build_pinned_client`,
@@ -28,9 +37,23 @@ commands given.
 
 ## Concurrency bounds
 
-Two independent semaphores bound the two expensive stages, each shedding
-load with a distinguishable error rather than queueing unboundedly:
+Three independent bounds shed load with a distinguishable error rather than
+queue unboundedly, at three different layers of the request:
 
+- **Router-level total concurrency**: `saturation_and_timeout_middleware`
+  (`src/modules/router/middlewares.rs`, #43) wraps every route in a
+  fixed-size `tokio::sync::Semaphore` (`MAX_CONCURRENT_REQUESTS`, default
+  512) plus a `tokio::time::timeout` (`REQUEST_TIMEOUT_SECS`, default 30s).
+  A non-blocking `try_acquire_owned()` sheds with `503` the instant the
+  service is at capacity, standing in for
+  `tower::limit::ConcurrencyLimitLayer` + `tower_http::timeout::TimeoutLayer`
+  (neither `tower`'s `limit`/`load-shed` nor tower-http's `timeout` feature
+  is enabled in this workspace's `Cargo.toml`). A per-IP token-bucket rate
+  limiter (`tower_governor`, `RATE_LIMIT_BURST`/`RATE_LIMIT_PERIOD_MS`,
+  default 20 burst / 100ms refill) sits in front of it. These four
+  variables are read directly from the process environment in
+  `middlewares.rs`, not via `EnvConfig`/`envconfig` like the rest of this
+  document's variables - see `docs/configuration/performance.md`.
 - **Downloads**: `download_semaphore`, sized from `max_concurrent_downloads`
   (default 20), acquired with a blocking `.acquire()` in `download_image` -
   a download that can't get a permit right away waits for one, since a
@@ -47,6 +70,18 @@ load with a distinguishable error rather than queueing unboundedly:
   concurrent calls to `process_image`, so the real limiting factor was
   whatever ran the CPU stage.
 
+Separately from all three, **single-flight request coalescing**
+(`src/services/resize/handler.rs`, #37) means concurrent callers asking for
+the *same cache key* never multiply load in the first place: once a cache
+miss is confirmed, the first caller becomes the leader (registered in a
+`dashmap`-backed in-flight map) and does the real download/process/upload
+work; every other concurrent caller for that key subscribes to a
+`tokio::sync::broadcast` channel and receives the leader's result instead of
+running its own. An `InFlightGuard` with a `Drop` impl guarantees followers
+are unblocked (with a synthetic failure) even if the leader panics or its
+future is cancelled mid-flight, so a dead leader can never leave a follower
+waiting forever.
+
 ### Why `tokio::task::spawn_blocking`, not a custom rayon pool
 
 The CPU stage used to run on a hand-rolled `rayon::ThreadPool`
@@ -62,9 +97,11 @@ the runtime. `process_image` now moves the decode/resize/encode work onto
 `tokio::task::spawn_blocking`, gated by the `processing_semaphore` above, and
 still off the async runtime's own worker threads.
 
-`rayon` remains listed in `Cargo.toml` as a dependency (this document's
-owner does not have permission to edit `Cargo.toml` in the change that
-removed its last use) but nothing in `src/` references it any more.
+`rayon` is no longer a dependency at all - it has been removed from
+`Cargo.toml` entirely (`grep -c '^rayon' Cargo.toml` returns 0). It still
+appears, transitively, in `Cargo.lock` (pulled in by other dependencies
+unrelated to this crate's own code), but nothing in this crate's
+`Cargo.toml` or `src/` references it.
 
 ### Cancellation on caller disconnect
 
@@ -114,18 +151,71 @@ bounds *queued*, not in-flight, waste.
 
 - **Format detection** from magic bytes, avoiding a second guess-the-format
   pass when the bytes are already in hand.
-- **Filter selection**: `Triangle` for small (<=300px per side) targets,
-  `Lanczos3` otherwise - a real, measured lever (see Benchmarks below), not
-  yet configurable per request (#35).
+- **Resize** goes through [`fast_image_resize`](https://docs.rs/fast_image_resize)
+  (SIMD), not the `image` crate's own resize kernel (#63 stage 1). Filter
+  selection is unchanged in name - `Triangle` for small (<=300px per side)
+  targets, `Lanczos3` otherwise, a real, measured lever, not yet
+  configurable per request (#35) - but is now mapped onto
+  `fast_image_resize`'s own filter set (`Triangle` -> `fir::FilterType::Bilinear`,
+  `Lanczos3` -> `fir::FilterType::Lanczos3` by name) instead of the `image`
+  crate's kernel. Measured ~5x faster on a downscale for the same filter
+  (`resize_fir/downscale lanczos3`: 3.43ms vs. the old `image`-crate
+  kernel's ~17ms in `.bench-baseline/BASELINE.md`), with imperceptible
+  quality difference (DSSIM 0.0000047-0.0000093 against the old kernel's
+  output, same source).
+- **JPEG decode** goes through `mozjpeg`/libjpeg-turbo instead of the
+  `image` crate's `zune-jpeg` (#63 stage 2, extended by #67). Two paths:
+  - **DCT-scaled decode**: when the requested output is a >=2x downscale,
+    `select_jpeg_dct_scale` (`src/services/image/handler.rs`) picks the most
+    aggressive libjpeg DCT scale (`scale_num`/8, i.e. 1/2, 1/4, or 1/8) whose
+    decoded output is still >= the resize target, and decodes directly at
+    that resolution instead of decoding full-size and discarding most of the
+    data during resize. Measured 2.21x faster for a 4K source to a small
+    thumbnail (26.21ms vs 58.03ms for full decode + resize).
+  - **Full-size mozjpeg decode**, otherwise - as of #67, this replaced the
+    `image`-crate/`zune-jpeg` decode for *every* JPEG, not just the
+    DCT-scaled case: `image` 0.25.10's `zune-jpeg` 0.5.x made its Huffman
+    bit-refill EOF check fallible where 0.4.x's was an infallible `bool`, a
+    real per-byte cost; mozjpeg's full-size decode measured ~1.5x faster
+    across a 36-photo real corpus regardless of downscale ratio.
+  - Either path falls back to the `image`-crate decoder on any mozjpeg
+    failure (including a caught panic) rather than failing the request.
+- **JPEG encode** goes through `mozjpeg::Compress` instead of
+  `image::codecs::jpeg::JpegEncoder` (#76) - the `image` crate's encoder has
+  no progressive-mode switch and hardcodes 4:2:2 chroma subsampling, so
+  neither could be exposed through it. Two profiles:
+  - **`JCP_FASTEST`** (mozjpeg's `set_fastest_defaults`) for the default,
+    non-progressive path - ~5% smaller and 3-4x *faster* than the old
+    `image`-crate encoder, and scores a better mean DSSIM than mozjpeg's own
+    max-compression profile at the same nominal quality (trellis
+    quantisation trades fidelity for size, not the other way round).
+  - **`JCP_MAX_COMPRESSION`** (mozjpeg's own default profile, which turns on
+    trellis quantisation unconditionally) only for explicitly-requested
+    progressive output (`jpgo:1:...`) - ~12% smaller than the old encoder
+    but 3-8x its encode time, so it is charged only to requests that opt in.
+    Constructing a `mozjpeg::Compress` without calling
+    `set_fastest_defaults` selects this profile by default, which very
+    nearly shipped as the default for *every* JPEG encode (a +16% pipeline
+    regression) - see `.bench-baseline/BASELINE.md`'s "JPEG encoder
+    cutover" section for the full trap.
+- **WebP** goes through the [`webp`](https://docs.rs/webp) crate (real
+  libwebp) instead of the `image` crate's lossless-only WebP encoder (#32,
+  #60) - lossy and lossless static images via `webp::Encoder`, animated WebP
+  via `webp::AnimEncoder`/`AnimFrame`. See `adr/0001-image-engine.md` and
+  `adr/0003-webp-measurement.md` for why and how this was measured.
+- **AVIF** is encode-only, via `image::codecs::avif::AvifEncoder`. See
+  `adr/0004-avif-measurement.md`.
 - **Upscale guard, off by default** (#36): a request naming output
   dimensions larger than the source image is capped to the source's
   dimensions per axis unless the request opts in via `enlarge: true`
   (`ResizeQuery::enlarge`, `src/models/params.rs`), mirroring imgproxy's
   `enlarge` option. Upscaling is measurably expensive - the committed
   benchmark baseline (`.bench-baseline/BASELINE.md`) puts
-  `resize/upscale/lanczos3` at 143ms vs 17.4ms for the equivalent downscale,
-  ~8x - so leaving it unguarded let a single request against a tiny source
-  name an arbitrarily expensive output size.
+  `resize/upscale/lanczos3` at 143ms vs 17.4ms for the equivalent downscale
+  on the old `image`-crate kernel (~8x; the `fast_image_resize` upscale path
+  is faster in absolute terms but shows the same multiplier) - so leaving it
+  unguarded let a single request against a tiny source name an arbitrarily
+  expensive output size.
 - **No redundant crop**: the fixed-size ("fill") resize path used to check
   whether `resize_to_fill`'s output already matched the requested dimensions
   before conditionally cropping. `resize_to_fill` always crops to exactly
@@ -170,14 +260,20 @@ explicitly (as the Dockerfile does for the shipped binaries).
 
 ## Runtime configuration
 
-- **Tokio runtime**: `#[tokio::main(flavor = "multi_thread", worker_threads
-  = 4)]` (`src/main.rs`) - a fixed 4 async worker threads regardless of host
-  core count.
+- **Tokio runtime**: no longer built via the `#[tokio::main]` attribute
+  macro (that only accepts compile-time literals, so a fixed worker count
+  was baked in). `src/main.rs` now builds the runtime by hand with
+  `tokio::runtime::Builder::new_multi_thread().worker_threads(n)`, where `n`
+  is `TOKIO_WORKER_THREADS` if set, else `effective_cpu_count()` - the same
+  cgroup-aware CPU count used to size `max_concurrent_processing`
+  (`src/modules/utils/cgroup.rs`, #44), not `num_cpus::get()` directly, so a
+  CPU-quota-limited container sizes the runtime for its actual quota rather
+  than the host's full core count.
 - **Allocator**: `mimalloc` as the global allocator (`src/main.rs`).
 
 ## Benchmarking
 
-Reproduce the pipeline numbers below (decode + resize + optional filters +
+Reproduce the pipeline numbers (decode + resize + optional filters +
 encode, via `ImageService::process_image_blocking`, the same code path
 production traffic runs - see that function's doc comment):
 
@@ -187,37 +283,31 @@ cargo bench --features local_fs --bench pipeline -- --sample-size 20 --measureme
 
 Other benches cover the pipeline stages and cache-key hashing in isolation:
 `cargo bench --features local_fs --bench decode|resize|encode|cache_key`.
-`.bench-baseline/BASELINE.md` and `.bench-baseline/P0-COMPARISON.md` have
-the full per-filter/per-format numbers and the observation that upscaling
-runs ~8x slower than the equivalent downscale, which is what motivates the
-upscale guard above.
 
-Measured on this machine (darwin/arm64), `cargo bench --features local_fs
---bench pipeline -- --sample-size 20 --measurement-time 2 --warm-up-time 1`,
-criterion default (release) profile - not `perf`:
+This document does not embed a snapshot of those numbers - they move too
+often (five documented, code-verified changes since this document was first
+written: the `fast_image_resize` kernel swap, DCT-scaled JPEG decode, wave-2
+features, the JPEG encoder cutover, and full-size mozjpeg decode) for a
+copy pasted here to stay honest for long. **`.bench-baseline/BASELINE.md`
+is the current, single source of truth for every criterion number**,
+including the full per-filter/per-format table, the observation that
+upscaling runs ~8x slower than the equivalent downscale (what motivates the
+upscale guard above), and a running log of measurement traps this project
+has already fallen into once (stale encoder defaults, redirect-blended
+end-to-end metrics, DCT-scale threshold assumptions) so the next person
+re-running these benches doesn't repeat them.
 
-| Case | Before (#30/#31, `.bench-baseline/BASELINE.md`) | After |
-|---|---|---|
-| photo_like -> thumbnail jpg | 14.88 ms | ~15.5 ms |
-| flat -> resize png | 32.81 ms | ~33.1 ms |
-| alpha -> resize webp | 2.94 ms | ~3.0 ms |
+**End-to-end, against imgproxy**: the criterion numbers above are
+single-operation micro-benchmarks inside the Rust binary; they do not cover
+routing, source fetch, storage round trips, or the redirect hop. The full
+three-way comparison against imgproxy (`bench-imgproxy/`, a k6 harness) is
+also tracked in `.bench-baseline/BASELINE.md`, and is summarized honestly in
+the [README's Performance section](README.md#performance) - emgr is
+measurably slower than imgproxy on a cold cache (3.26x on p50) and
+measurably faster on a warm one (imgproxy has no result cache of its own),
+which is the same architectural trade-off seen from two sides, not two
+independent facts.
 
-These deltas (roughly +1% to +5%) are within the run-to-run noise this exact
-bench already showed across the P0 security-fix changes documented in
-`.bench-baseline/P0-COMPARISON.md` (deltas up to +7.5% there, symmetric in
-both directions, which is what noise looks like rather than a regression).
-That tracks: this particular bench calls
-`ImageService::process_image_blocking` directly, which does not go through
-`process_image`'s semaphore/`spawn_blocking` change or `download_image`'s
-`Bytes` change at all - #30 and #31 are concurrency and allocation changes
-on the async/download path, not changes to the decode/resize/encode
-arithmetic this bench measures. What it does exercise is the upscale-guard
-addition and the dead-crop-branch removal, both a handful of comparisons
-against an already-decoded image, consistent with a change too small to
-separate from noise here.
-
-No throughput/memory/CPU-utilization multipliers are claimed in this
-document. If you want one, produce it with a load-generation harness against
-the full `resize` HTTP path (which does exercise the semaphore and `Bytes`
-changes end-to-end) and cite the exact command and hardware, per the standard
-this document now holds itself to.
+No throughput/memory/CPU-utilization multiplier is claimed anywhere in this
+document that doesn't trace to a command and a number in
+`.bench-baseline/BASELINE.md` or `bench-imgproxy/README.md`.

--- a/README.md
+++ b/README.md
@@ -1,189 +1,193 @@
-# EmgR - Image Resizing Service
+# EmgR — Image Resizing Service
 
-EmgR is a high-performance image resizing service built with Rust, designed to efficiently process and deliver images in various formats and sizes. It leverages asynchronous processing with Tokio and the Axum web framework for robust and scalable performance.
+EmgR is an imgproxy-compatible, on-the-fly image resizing service written in Rust (Axum + Tokio). It fetches a source image, decodes/resizes/encodes it per an HMAC-signed URL, caches the result to a storage backend, and 301-redirects the caller to the cached bytes.
 
-## Features
+It aims to be a credible, self-hosted alternative to [imgproxy](https://imgproxy.net/) — see the [Performance](#performance) section below for an honest, measured comparison against imgproxy v4.0.13, not a marketing claim.
 
-*   **Dynamic Image Resizing**: Resize images on-the-fly via an imgproxy-compatible signed URL path, specifying source, dimensions, and output format.
-*   **Multiple Output Formats**: Supports common image formats like JPG, PNG, and WebP.
-*   **Efficient Caching**: (Implicit) Resized images are cached to ensure fast delivery for subsequent requests.
-*   **Storage Agility**: Supports multiple storage backends for resized images:
-    *   Local filesystem
-    *   AWS S3 (or S3-compatible services like MinIO)
-    *   In-memory (primarily for testing or specific use-cases)
-*   **Signed URLs**: HMAC-SHA256 request signing, matching imgproxy's scheme closely enough that a client library written for imgproxy works against this service (see [GH #27](https://github.com/vaam-store/image-resizer/issues/27)). Signing is the default, not opt-in.
-*   **Containerized**: Easily deployable using Docker and Docker Compose.
-*   **Observability**: Integrated with Jaeger for tracing via OpenTelemetry.
+## URL shape
 
-## Technology Stack
+Requests use imgproxy's signed-path grammar, not query parameters:
 
-*   **Language**: Rust (Edition 2024)
-*   **Web Framework**: Axum (hand-written router - no OpenAPI code generation, see [GH #53](https://github.com/vaam-store/image-resizer/issues/53))
-*   **Async Runtime**: Tokio
-*   **Image Processing**: `image` crate
-*   **Containerization**: Docker, Docker Compose
-*   **Tracing**: Jaeger, OpenTelemetry
-*   **Dependencies**: `reqwest` (HTTP client), `sha2`/`hmac` (hashing/signing), `envconfig` (configuration), `aws-sdk-s3` (for S3 storage).
+```
+GET /{signature}/{processing_options}/{plain|base64 source}.{extension}
+```
 
-## Getting Started
+- **`{signature}`** — base64url HMAC-SHA256 over the rest of the path, keyed by `SIGNING_KEY`/`SIGNING_SALT` — or the literal `unsigned` when `ALLOW_UNSIGNED_REQUESTS=true`. Signing is the default, not opt-in.
+- **`{processing_options}`** — zero or more `/`-delimited `code:args` segments, e.g. `rs:fill:300:300` (resize/crop), `q:80` (quality), `bl:5` (blur), `g:true` (grayscale), `el:1` (allow upscaling), `jpgo:1:0` (progressive JPEG / chroma subsampling), `wm:1` / `wmu:{base64url}` (watermark), `pr:{name}` (preset).
+- **`{source}`** — plain or base64url-encoded source image URL.
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
+Full grammar, every response code, and how to compute a signature in Python/JavaScript/bash: [API reference](docs/user-guide/api-reference.md) and [Examples](docs/user-guide/examples.md).
 
-### Prerequisites
+Design rationale for choosing this shape over query parameters or OpenAPI codegen: [ADR 0002](adr/0002-url-api-shape.md).
 
-*   Docker and Docker Compose
-*   `make` (optional, for using Makefile commands)
-*   `curl` (for testing)
+## Request flow
 
-### Installation & Running
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Router as axum router<br/>(src/modules/router/router.rs:48)
+    participant Resize as resize_handler<br/>(src/modules/api/resize.rs:23)
+    participant RS as ResizeService<br/>(src/services/resize/handler.rs:177)
+    participant Storage as StorageService
+    participant IS as ImageService<br/>(src/services/image/handler.rs)
+    participant Download as download_handler<br/>(src/modules/api/download.rs)
 
-1.  **Clone the repository:**
-    ```bash
-    git clone https://your-repository-url/emgr.git
-    cd emgr
-    ```
-    A fresh clone builds with plain `cargo build` - no Docker step needed
-    first (that used to require `make init` to run OpenAPI codegen; removed
-    under [GH #53](https://github.com/vaam-store/image-resizer/issues/53)).
+    Client->>Router: GET /{sig}/{options}/{source}.{ext}
+    Router->>Resize: route to resize_handler
+    Resize->>Resize: verify_or_reject (HMAC, resize.rs:90)<br/>403 on missing/bad signature
+    Resize->>RS: resize(query)
+    RS->>Storage: check_cache(key)
 
-2.  **Build the project images:**
-    This command builds the Docker images defined in [`compose.yaml`](compose.yaml:1).
-    ```bash
-    make build
-    ```
+    alt cache hit
+        Storage-->>RS: hit
+        RS-->>Resize: cached CDN url
+    else cache miss
+        RS->>RS: single-flight entry (handler.rs:205)<br/>dashmap keyed by cache key
+        alt this caller is leader
+            RS->>IS: download_image(url)<br/>bounded by download_semaphore (#30)
+            IS-->>RS: image bytes (Bytes, no copy)
+            RS->>IS: process_image on spawn_blocking<br/>bounded by processing_semaphore (#30)<br/>decode -> resize -> encode
+            IS-->>RS: encoded output
+            RS->>Storage: upload(key, bytes)
+            RS-->>RS: broadcast result to followers (Drop of InFlightGuard)
+        else this caller is follower
+            RS->>RS: await leader's broadcast result
+        end
+        RS-->>Resize: CDN url
+    end
 
-3.  **Start the application and dependent services (including Jaeger for tracing):**
-    This brings up the `app` service and its dependencies (like `tracking` for Jaeger). The application will be accessible on port `13001`.
-    ```bash
-    make up
-    ```
-    Alternatively, to start only the application:
-    ```bash
-    make up-app
-    ```
+    Resize-->>Client: 301 Location: /api/images/files/{key}
+    Client->>Router: GET /api/images/files/{key}
+    Router->>Download: route to download_handler (unsigned)
+    Download->>Storage: fetch bytes for key
+    Storage-->>Download: image bytes
+    Download-->>Client: 200 image bytes
+```
 
-4.  **Verify the application is running:**
-    You can check the status of the containers:
-    ```bash
-    make ps
-    # or
-    docker compose -p emgr ps
-    ```
-    View application logs:
-    ```bash
-    make logs-app
-    ```
-    Jaeger UI will be available at: `http://localhost:16686`
+Two independent semaphores shed load with a `503` rather than queue unboundedly — `download_semaphore` (`max_concurrent_downloads`, default 20) and `processing_semaphore` (`max_concurrent_processing`, default CPU count), both in `src/services/image/handler.rs` (#30). A third, separate semaphore bounds total in-flight HTTP requests at the router level (`MAX_CONCURRENT_REQUESTS`, default 512, `src/modules/router/middlewares.rs`, #43). Concurrent requests for the *same* cache key are coalesced by a single-flight leader/follower registry (`src/services/resize/handler.rs`, #37) so only one of them actually does the work — see [`PERFORMANCE_OPTIMIZATIONS.md`](PERFORMANCE_OPTIMIZATIONS.md) for the mechanics of all three.
 
-### Testing the Resize Endpoint
+Never a redirect back to the caller-supplied source ([GH #25](https://github.com/vaam-store/image-resizer/issues/25)) — the `Location` header always points at this service's own storage-backed URL.
 
-The resize endpoint takes an HMAC-signed URL path, not query parameters -
-see the [API reference](docs/user-guide/api-reference.md) for the full
-grammar and [Examples](docs/user-guide/examples.md) for how to compute a
-signature in Python/JavaScript/bash. With the placeholder
-`SIGNING_KEY=6d792d7369676e696e672d6b6579` /
-`SIGNING_SALT=6d792d73616c74` from [`.env.example`](.env.example) (never
-use these for anything real) and the service listening on `localhost:13001`:
+## Image engine
+
+- **Resize**: [`fast_image_resize`](https://docs.rs/fast_image_resize) (SIMD), not the `image` crate's own resize kernel — roughly 5x faster on a downscale (`resize_fir/downscale lanczos3`: 3.43ms vs. the `image`-crate kernel's 17ms; see [`.bench-baseline/BASELINE.md`](.bench-baseline/BASELINE.md)).
+- **JPEG decode**: [`mozjpeg`](https://docs.rs/mozjpeg)/libjpeg-turbo, with DCT-scaled decode at 1/2, 1/4, or 1/8 resolution when the requested output is a ≥2x downscale, falling back to a full-size mozjpeg decode otherwise.
+- **JPEG encode**: `mozjpeg` at the `JCP_FASTEST` profile by default — smaller and faster than the old `image`-crate encoder on every axis measured. Explicitly-requested progressive output (`jpgo:1:...`) gets the full `JCP_MAX_COMPRESSION` profile instead, since that cost (~19x baseline) is opt-in only.
+- **WebP**: the [`webp`](https://docs.rs/webp) crate — real libwebp, lossy and lossless, plus animated WebP via `AnimEncoder`.
+- **AVIF**: encode only, via the `image` crate's `AvifEncoder`.
+- **PNG / GIF**: the `image` crate.
+
+See [ADR 0001](adr/0001-image-engine.md) (engine choice), [ADR 0003](adr/0003-webp-measurement.md) (WebP byte-size, re-measured), and [ADR 0004](adr/0004-avif-measurement.md) (AVIF byte-size/encode-time, measured) for the reasoning and data behind these choices.
+
+## Storage backends
+
+Selected via `STORAGE_TYPE` and gated by Cargo feature flags — only the backend(s) the binary was compiled with are available:
+
+| Feature | Backend | Notes |
+|---|---|---|
+| `local_fs` | Local filesystem | `LOCAL_FS_STORAGE_PATH` |
+| `s3` | S3 / MinIO-compatible | `MINIO_ENDPOINT_URL`, `MINIO_ACCESS_KEY_ID`, `MINIO_SECRET_ACCESS_KEY`, `MINIO_BUCKET`, `MINIO_REGION` |
+| `in_memory` | In-process map | Test-only — compiled only under `cfg(test)` even when this feature is on, so it is never reachable from a real running binary, not just "discouraged in production" |
+| `otel` | — | Not a storage backend: enables OpenTelemetry tracing/metrics export (Jaeger/OTLP) and mounts an authenticated `/metrics` endpoint. Independent of the three above. |
+
+## Quick start
+
+### Docker Compose
+
+```bash
+git clone https://your-repository-url/emgr.git
+cd emgr
+cp .env.example .env   # then set real SIGNING_KEY/SIGNING_SALT — see below
+make up                # or: docker compose -p emgr -f compose.yaml up -d --build
+```
+
+This builds the `app` service (the `fs_otel_deploy` Docker target — `local_fs` storage + `otel`) plus its `tracking` (Jaeger) dependency. The app listens on `13001` (see `compose.yaml`); Jaeger UI is at `http://localhost:16686`. `make help` lists every other target (`down`, `destroy`, `logs`, `ps`, ...).
+
+### Cargo
+
+```bash
+git clone https://your-repository-url/emgr.git
+cd emgr
+cargo build --features local_fs   # or: s3, or "local_fs otel", or "s3 otel"
+cargo run --features local_fs
+```
+
+A fresh clone builds directly with `cargo build` — no code-generation step, no Docker requirement first (that used to require `make init` to run OpenAPI codegen against `openapi.yaml`; both are gone, [GH #53](https://github.com/vaam-store/image-resizer/issues/53) replaced the generated router with a hand-written one). At least one of `local_fs`/`s3` must be enabled or the process has no storage backend to start with.
+
+### Try the resize endpoint
+
+With the placeholder `SIGNING_KEY=6d792d7369676e696e672d6b6579` / `SIGNING_SALT=6d792d73616c74` from [`.env.example`](.env.example) (never use these for anything real) and the service listening on `localhost:13001`:
 
 ```bash
 curl -LI 'http://localhost:13001/de7BKgwO8wFeNZWRWgp3UB9jKwOkVoYM_eMKau2ECgw/rs:fill:300:300/q:80/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg'
 ```
 
-You should see a `301 Moved Permanently` response, with a `Location` header pointing to the resized image:
-
-```plaintext
-HTTP/1.1 301 Moved Permanently
-location: http://localhost:13001/api/images/files/your-image-hash.jpg
-vary: origin, access-control-request-method, access-control-request-headers
-access-control-allow-origin: *
-content-length: 0
-date: Sat, 31 May 2025 XX:XX:XX GMT
-
-HTTP/1.1 200 OK
-content-type: image/jpeg
-vary: origin, access-control-request-method, access-control-request-headers
-access-control-allow-origin: *
-content-length: XXXXXX
-date: Sat, 31 May 2025 XX:XX:XX GMT
-```
-
-You can then open the `location` URL in your browser to view the resized image, for example:
-```bash
-open http://localhost:13001/api/images/files/your-image-hash.jpg
-```
-Or, open the signed resize URL directly (which will perform the resize and then redirect):
-```bash
-open 'http://localhost:13001/de7BKgwO8wFeNZWRWgp3UB9jKwOkVoYM_eMKau2ECgw/rs:fill:300:300/q:80/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg'
-```
-
-### Other Useful Commands
-
-*   **Stop the project:**
-    ```bash
-    make down
-    ```
-*   **Destroy the project (stops and removes containers, networks, and volumes):**
-    ```bash
-    make destroy
-    ```
-*   **View all logs:**
-    ```bash
-    make logs
-    ```
-*   **Show help (lists all Makefile targets):**
-    ```bash
-    make help
-    ```
-
-## API Endpoints
-
-The full grammar and every response code live in the
-[API reference](docs/user-guide/api-reference.md) - there is no
-`openapi.yaml` any more ([GH #53](https://github.com/vaam-store/image-resizer/issues/53)
-replaced OpenAPI code generation with a hand-written router). Summary:
-
-*   `GET /{signature}/{processing_options}/{plain|base64 source}.{extension}`
-    *   **Summary**: HMAC-signed, imgproxy-compatible resize URL. Fetches the source, resizes/transforms it, caches the result, and redirects to it.
-    *   **`{signature}`**: base64url HMAC-SHA256 over the rest of the path, keyed by `SIGNING_KEY`/`SIGNING_SALT` (see [Configuration](#configuration)) - or the literal `unsigned` when `ALLOW_UNSIGNED_REQUESTS=true` is set. Signing is the default, not opt-in.
-    *   **`{processing_options}`**: zero or more `/`-delimited `code:args` segments - `rs:{type}:{w}:{h}` (resize/crop), `q:{0-100}` (quality), `bl:{sigma}` (blur), `g:{true|false}` (grayscale), `el:{1|0}` (allow upscaling).
-    *   **Responses**:
-        *   `301 Moved Permanently`: Redirects to the path of the resized image. The `Location` header contains the URL to the processed image. (Never a redirect to the caller-supplied source - see [GH #25](https://github.com/vaam-store/image-resizer/issues/25).)
-        *   `400 Bad Request`: The signed-URL path is malformed, or the source URL doesn't decode as an image, or exceeds a configured limit.
-        *   `403 Forbidden`: The signature is missing, invalid, or `unsigned` without `ALLOW_UNSIGNED_REQUESTS=true`.
-        *   `502 Bad Gateway`: The origin server for the requested image failed.
-        *   `503 Service Unavailable`: The service is shedding load (concurrency limits reached).
-
-*   `GET /api/images/files/{key}`
-    *   **Summary**: Downloads a previously resized image. Unsigned - only ever serves already-cached, hash-addressed bytes, not an arbitrary fetch.
-    *   **Path Parameters**:
-        *   `key` (string, required): The unique key (hash) of the image file.
-    *   **Responses**:
-        *   `200 OK`: Returns the image file with the appropriate `Content-Type` (e.g., `image/png`, `image/jpeg`).
+Expect a `301 Moved Permanently` with a `Location` pointing at `/api/images/files/{key}`; following it returns `200` with the resized image bytes. Compute your own signature for a real source URL with the snippets in [Examples](docs/user-guide/examples.md).
 
 ## Configuration
 
-The application is configured entirely via environment variables, read by
-[`src/modules/env/env.rs`](src/modules/env/env.rs). The full, CI-checked
-reference lives at
-[`docs/getting-started/configuration.md`](docs/getting-started/configuration.md)
-(covers storage backend selection, the SSRF source-fetch guard,
-resolution/output limits, performance tuning, and observability). A
-starting-point `.env` file is at [`.env.example`](.env.example) - copy it
-to `.env` (gitignored). The most commonly-touched variables, as seen in
-[`compose.yaml`](compose.yaml):
+The service is configured entirely via environment variables, read by [`src/modules/env/env.rs`](src/modules/env/env.rs). The full, CI-checked reference (kept in sync with `env.rs` by a dedicated `docs-env-drift` CI job) is [`docs/getting-started/configuration.md`](docs/getting-started/configuration.md); performance-specific knobs (concurrency limits, HTTP client tuning, request-timeout/rate-limit shedding, the `PERFORMANCE_PROFILE` presets) are in [`docs/configuration/performance.md`](docs/configuration/performance.md). [`.env.example`](.env.example) is a starting point — copy it to `.env` (gitignored).
 
-*   `STORAGE_TYPE`: Storage backend - `LOCAL_FS` or `S3` (alias `MINIO`).
-*   `CDN_BASE_URL`: The base URL for constructing links to served image files (e.g., `http://localhost:13001/api/images/files`).
-*   `SIGNING_KEY` / `SIGNING_SALT`: Hex-encoded HMAC-SHA256 key/salt for signed URLs ([GH #27](https://github.com/vaam-store/image-resizer/issues/27)). Required unless `ALLOW_UNSIGNED_REQUESTS=true` - signing is the default, the process refuses to start without one or the other.
-*   `LOG_LEVEL`: Sets the logging verbosity (e.g., `info`, `debug`).
-*   `OTLP_SPAN_ENDPOINT`: Endpoint for OpenTelemetry trace collector (Jaeger).
-*   `OTLP_METRIC_ENDPOINT`: Endpoint for OpenTelemetry metrics collector.
-*   `OTLP_SERVICE_NAME`: Service name for OpenTelemetry.
+Most commonly touched:
+
+- `STORAGE_TYPE` — `LOCAL_FS` or `S3` (alias `MINIO`).
+- `CDN_BASE_URL` — base URL used to build the redirect `Location`.
+- `SIGNING_KEY` / `SIGNING_SALT` — hex-encoded HMAC-SHA256 key/salt for signed URLs ([GH #27](https://github.com/vaam-store/image-resizer/issues/27)). Required unless `ALLOW_UNSIGNED_REQUESTS=true` — the process fails closed at startup without one or the other.
+- `METRICS_AUTH_TOKEN` — bearer token required on `/metrics` when built with `--features otel`; also fails closed at startup unless `ALLOW_UNAUTHENTICATED_METRICS=true` ([GH #77](https://github.com/vaam-store/image-resizer/issues/77)).
+
+## API endpoints
+
+Full grammar and every response code: [API reference](docs/user-guide/api-reference.md). Summary:
+
+- `GET /{signature}/{processing_options}/{plain|base64 source}.{extension}` — signed resize request. `301` to the cached result, `400` on a malformed path or undecodable/oversized source, `403` on a bad/missing signature, `502` if the origin fetch fails, `503` when a concurrency limit is shedding load.
+- `GET /api/images/files/{key}` — unsigned download of an already-cached, hash-addressed result. Never performs an arbitrary fetch.
+- `GET /health` — unauthenticated liveness/readiness probe target.
+- `GET /metrics` — Prometheus metrics, only mounted with `--features otel`, bearer-token authenticated by default.
+
+## Performance
+
+**Cold cache** (per delivered image, medians of 3 runs, imgproxy v4.0.13, darwin/arm64 — see [`.bench-baseline/BASELINE.md`](.bench-baseline/BASELINE.md)):
+
+| Engine | p50 | images/s |
+|---|---:|---:|
+| imgproxy | 20.50 ms | 64.51 |
+| emgr (local_fs) | 66.82 ms | 23.56 |
+
+**emgr is 3.26x slower on p50 and delivers 2.74x less throughput than imgproxy on a cold cache.** This project does not claim parity with imgproxy on raw processing speed, and this README will not pretend otherwise.
+
+**Warm cache**, same run set:
+
+| Engine | p50 | images/s |
+|---|---:|---:|
+| imgproxy | 20.10 ms | 64.94 |
+| emgr (local_fs) | 0.39 ms | 4852 |
+
+This is not a processing-speed win — it's a different architecture. imgproxy has no result cache and reprocesses every request; a production imgproxy deployment normally sits behind a CDN to absorb repeat requests. emgr instead redirects a repeat request straight to its own storage-backed cache before the pipeline ever runs. The cold cost and the warm win are **the same trade-off** seen from two sides: emgr's request path is process → write to storage → `301` → client re-fetches from storage, which is exactly why a cache miss costs an extra round trip (cold) and why a cache hit is nearly free (warm). You cannot remove one without losing the other. Which number matters more depends on your cache-hit rate in production — a number these benchmarks don't measure for you.
+
+Micro-benchmarks (single-operation, criterion, darwin/arm64):
+
+| Operation | Time |
+|---|---:|
+| JPEG decode, 1920x1080 | 7.20 ms |
+| JPEG encode (baseline) | 933 µs |
+| JPEG encode (progressive) | 17.81 ms |
+| PNG encode | 1.71 ms |
+| WebP encode | 24.26 ms |
+| Resize, downscale, Lanczos3 (`fast_image_resize`) | 3.43 ms |
+| Resize, downscale, Triangle→Bilinear (`fast_image_resize`) | 1.15 ms |
+| Full pipeline, photo → thumbnail JPEG | 6.17 ms |
+| Full pipeline, 4K photo → large downscale | 19.65 ms |
+
+Full methodology, every measured number, and the traps that produced misleading intermediate readings along the way (encoder-profile defaults, redirect-blended metrics, DCT-scale thresholds) are in [`.bench-baseline/BASELINE.md`](.bench-baseline/BASELINE.md), the mechanism-level writeup in [`PERFORMANCE_OPTIMIZATIONS.md`](PERFORMANCE_OPTIMIZATIONS.md), the tunable knobs in [`docs/configuration/performance.md`](docs/configuration/performance.md), and the end-to-end harness itself in [`bench-imgproxy/README.md`](bench-imgproxy/README.md).
+
+## Observability
+
+Built with `--features otel`: OpenTelemetry traces/metrics exported via OTLP (`OTLP_SPAN_ENDPOINT`, `OTLP_METRIC_ENDPOINT`), a bearer-token-authenticated `/metrics` Prometheus endpoint, and structured logging (`LOG_LEVEL`). `docker compose up` brings up Jaeger (`tracking` service) as a local OTLP collector/UI.
 
 ## Contributing
 
-Please read `CONTRIBUTING.md` for details on our code of conduct, and the process for submitting pull requests to us. (Note: `CONTRIBUTING.md` to be created)
+See [`docs/development/contributing.md`](docs/development/contributing.md).
 
 ## License
 
-This project is licensed under the MIT License - see the [`LICENSE`](LICENSE:0) file for details.
+MIT — see [`LICENSE`](LICENSE).

--- a/adr/0002-url-api-shape.md
+++ b/adr/0002-url-api-shape.md
@@ -225,12 +225,24 @@ cannot both own the prefix.
 **Decision: `g:` stays grayscale; gravity is `gr:`.** Taken by the repository owner on
 2026-08-20, in preference to reassigning `g:` to gravity and moving grayscale to `gs:`.
 
-**Consequence, stated plainly so it is not rediscovered later:** `emgr` is *not* drop-in for an
-imgproxy URL that uses gravity. Such a URL does not error — it is silently misread, because
-`g:ce` parses as a valid grayscale option rather than centre gravity. Gravity is among the most
-commonly used imgproxy processing options, so the "swap your base URL" adoption story recorded
-above under Consequences is correspondingly narrower than that section implies: it holds for
-resize/quality/format/crop URLs, not for gravity ones.
+**Consequence:** `emgr` is *not* drop-in for an imgproxy URL that uses gravity. Gravity is among
+the most commonly used imgproxy processing options, so the "swap your base URL" adoption story
+recorded above under Consequences is correspondingly narrower than that section implies: it holds
+for resize/quality/format/crop URLs, not for gravity ones.
+
+**Correction (2026-08-21): this section previously claimed such a URL is "silently misread."
+That was wrong, and the real behaviour is considerably better.** `g:` routes its argument through
+`parse_bool` (`src/modules/url/options.rs`), which accepts only `true`/`1`/`false`/`0`. Every
+imgproxy gravity token — `ce`, `no`, `so`, `we`, `ea`, `noea`, `nowe`, `soea`, `sowe`, `sm`,
+`fp` — fails that parse and the request is rejected with **400 Bad Request**. A gravity URL
+carrying offsets (`g:ce:10:20`) fails the arity check first, for the same outcome.
+
+So a migrating user gets a clear, immediate error rather than a wrong image. That is the failure
+mode you want from an incompatibility: loud, at the boundary, and impossible to mistake for
+success. The original claim was written from the shape of the grammar without checking the
+parser, and it understated the design — worth recording as a correction rather than a silent
+edit, because "silently misread" is exactly the sort of claim that would justify reopening this
+decision on false grounds.
 
 **What would change this decision:** it becomes materially more expensive with every published
 `emgr` URL that uses `g:`. Today the grammar has no external users and the swap would cost only

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,21 +1,174 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+The previous version of this page was a 20-line template that predated
+essentially all of the functionality below. This reconstruction groups
+the project's `git log --oneline --merges origin/main` history by theme
+rather than listing every commit; PR numbers (`#NN`) link to
+`https://github.com/vaam-store/image-resizer/pull/NN`.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+`emgr` doesn't cut dated, tagged releases yet - `Cargo.toml`'s `version`
+has stayed `0.1.2` throughout everything below, and
+`.github/workflows/build.yml` has no release-tag trigger: every published
+Docker image is either a floating `<flavor>-latest` or a per-commit
+`<flavor>-<sha>` (see [Docker deployment](../deployment/docker.md)).
+Once real, tagged releases start, this file should switch to genuine
+dated version headings per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/);
+until then, everything below is "Unreleased" in that format's sense.
 
-## [Unreleased]
+## ⚠️ Breaking changes for existing deployments
 
-### Added
-- Initial setup of MkDocs documentation.
+- **Signed URLs are on by default** ([#27](https://github.com/vaam-store/image-resizer/issues/27)).
+  A deployment that previously ran without `SIGNING_KEY`/`SIGNING_SALT`
+  now refuses to start. Set both (hex-encoded), or set
+  `ALLOW_UNSIGNED_REQUESTS=true` to keep the old, unsigned behavior.
+- **`/metrics` now requires authentication on `otel` builds**
+  ([#77](https://github.com/vaam-store/image-resizer/issues/77)). A
+  deployment scraping `/metrics` without configuring
+  `METRICS_AUTH_TOKEN` now refuses to start. Set it and point
+  Prometheus's scrape config at it via its `authorization` block, or set
+  `ALLOW_UNAUTHENTICATED_METRICS=true`.
+- **OpenAPI code generation is gone**
+  ([#53](https://github.com/vaam-store/image-resizer/issues/53)).
+  `openapi.yaml` and the generated `packages/gen-server` crate no longer
+  exist - the HTTP router is hand-written. The wire API is unchanged, but
+  any tooling that depended on the generated crate or the spec file needs
+  updating. `make init`, the codegen bootstrap that used to be a
+  prerequisite for a fresh clone, is gone with it.
+- **Resize types honour imgproxy's real semantics instead of always
+  cropping** ([#59](https://github.com/vaam-store/image-resizer/issues/59),
+  [#1](https://github.com/vaam-store/image-resizer/issues/1)). A request
+  using a resize type other than `fill` now gets a different result than
+  before.
 
-## [1.0.0] - YYYY-MM-DD
+## Security
 
-### Added
-- First release of the Image Resize Service.
-- ... (details of features in 1.0.0)
+- SSRF-guarded source fetching: scheme validation, private/loopback/
+  link-local IP-range blocking (each with an explicit opt-in), a source
+  allowlist (`ALLOWED_SOURCES`), and re-validation on every redirect hop -
+  not just the original URL
+  ([#21](https://github.com/vaam-store/image-resizer/issues/21)).
+- `ALLOWED_SOURCES` fixed to actually authorise the private origins it
+  lists, instead of being silently overridden by the private-range guard
+  ([#57](https://github.com/vaam-store/image-resizer/issues/57)).
+- HMAC-SHA256 signed URLs, imgproxy-compatible, on by default
+  ([#27](https://github.com/vaam-store/image-resizer/issues/27)).
+- Cache-key validation shared by every storage backend, closing an
+  arbitrary-file-read via an unvalidated key (traversal, absolute paths,
+  percent-decoded forms) - see `tests/storage_key_validation.rs`
+  ([#23](https://github.com/vaam-store/image-resizer/issues/23)).
+- Resolution and output-size limits (`MAX_SRC_RESOLUTION_MP`,
+  `MAX_OUTPUT_WIDTH`/`MAX_OUTPUT_HEIGHT`, `MAX_ANIMATION_FRAMES`) -
+  guards against decode bombs and many-tiny-frame animation bombs
+  ([#26](https://github.com/vaam-store/image-resizer/issues/26)).
+- `/metrics` bearer-token authentication, fail-closed at startup on
+  `otel` builds, mirroring the signed-URL check
+  ([#77](https://github.com/vaam-store/image-resizer/issues/77)).
+- `cargo-deny` wired into CI: RUSTSEC advisory scanning, license checks,
+  duplicate/banned-crate checks, source-registry restriction (epic
+  [#9](https://github.com/vaam-store/image-resizer/issues/9)).
+- Alpha-channel compositing and transparent-pixel normalization fixed for
+  target formats without alpha support
+  ([#34](https://github.com/vaam-store/image-resizer/issues/34),
+  [#60](https://github.com/vaam-store/image-resizer/issues/60)).
+- Base container images (Rust builder, distroless runtime) pinned by
+  digest rather than a floating tag
+  ([#48](https://github.com/vaam-store/image-resizer/issues/48)).
 
----
+## Performance
 
-*This changelog is a template. Please update it with actual changes as the project evolves.*
+- SIMD image resampling via `fast_image_resize`, replacing the `image`
+  crate's scalar resampler (`#63` stage 1).
+- DCT-scaled JPEG decode via mozjpeg/libjpeg-turbo: decodes close to the
+  requested output size directly, instead of decoding full-size and
+  downsampling afterward (`#63` stage 2).
+- Full-size JPEG decode also routed through mozjpeg - measured ~1.5x
+  faster than the `image` crate's own decoder even without DCT scaling
+  ([#67](https://github.com/vaam-store/image-resizer/issues/67)).
+- JPEG encoding cut over to mozjpeg/libjpeg-turbo's `Compress`, replacing
+  the `image` crate's baseline encoder, alongside progressive-JPEG and
+  chroma-subsampling controls
+  ([#76](https://github.com/vaam-store/image-resizer/issues/76)).
+- CPU-bound image processing moved onto `tokio::spawn_blocking`, keeping
+  the async runtime responsive under load; a configurable performance
+  profile system (`PERFORMANCE_PROFILE`: high-throughput / low-latency /
+  memory-efficient) and concurrency limits (epic
+  [#9](https://github.com/vaam-store/image-resizer/issues/9)).
+- Cgroup-aware CPU-count detection for Tokio worker-thread and
+  concurrency sizing, instead of trusting the host's full core count from
+  inside a resource-limited container
+  ([#44](https://github.com/vaam-store/image-resizer/issues/44)).
+- A criterion micro-benchmark suite (`benches/`) plus a three-way
+  end-to-end harness against imgproxy (`bench-imgproxy/`), wired into a
+  CI regression gate with a 15% threshold and a PR comment report
+  ([#20](https://github.com/vaam-store/image-resizer/issues/20)).
+
+## Formats and processing options
+
+- Lossy and lossless WebP output, plus AVIF output
+  ([#35](https://github.com/vaam-store/image-resizer/issues/35),
+  [#4](https://github.com/vaam-store/image-resizer/issues/4),
+  [#49](https://github.com/vaam-store/image-resizer/issues/49)).
+- Animated GIF/WebP output, with a configurable frame-count cap
+  ([#49](https://github.com/vaam-store/image-resizer/issues/49)).
+- EXIF auto-orientation applied and ICC colour profiles forwarded to the
+  output ([#33](https://github.com/vaam-store/image-resizer/issues/33),
+  [#5](https://github.com/vaam-store/image-resizer/issues/5)).
+- Per-format quality control
+  ([#35](https://github.com/vaam-store/image-resizer/issues/35)).
+- Progressive JPEG and chroma-subsampling toggles, plus a `max_bytes`
+  output-size cap
+  ([#76](https://github.com/vaam-store/image-resizer/issues/76)).
+- imgproxy-compatible resize types (`fill`, `fit`, and the rest) instead
+  of always cropping regardless of the requested type
+  ([#59](https://github.com/vaam-store/image-resizer/issues/59)).
+- Gravity, crop and geometry options; watermarks; named presets
+  (`PRESETS`) and a processing-option allowlist
+  (`ALLOWED_PROCESSING_OPTIONS`)
+  ([#49](https://github.com/vaam-store/image-resizer/issues/49),
+  [#50](https://github.com/vaam-store/image-resizer/issues/50),
+  [#51](https://github.com/vaam-store/image-resizer/issues/51),
+  [#52](https://github.com/vaam-store/image-resizer/issues/52)).
+
+## Architecture and reliability
+
+- OpenAPI code generation removed: the HTTP router
+  (`src/modules/api`, `src/modules/router`, `src/modules/url`) is
+  hand-written now, so a fresh clone builds with plain `cargo build` and
+  no Docker/codegen step
+  ([#53](https://github.com/vaam-store/image-resizer/issues/53)).
+- Cache lifecycle grew TTL support and reachable stale/evicted states,
+  and local-filesystem writes became atomic (a directory could
+  previously be mistaken for a cache hit, and a partial write could be
+  served) - see `tests/storage_local_fs_atomicity.rs`
+  ([#38](https://github.com/vaam-store/image-resizer/issues/38),
+  [#40](https://github.com/vaam-store/image-resizer/issues/40)).
+- Graceful shutdown: SIGTERM/SIGINT drain in-flight requests before exit,
+  and OpenTelemetry providers flush on exit instead of losing buffered
+  telemetry on every restart
+  ([#42](https://github.com/vaam-store/image-resizer/issues/42)).
+- Docker images are now actually run-tested in CI before being pushed,
+  after the `s3`/`s3_otel` images shipped completely unable to start for
+  a period (a glibc mismatch between the Rust builder and the distroless
+  runtime - see [Docker deployment](../deployment/docker.md#the-builderruntime-base-image-pin---do-not-bump-casually))
+  ([#62](https://github.com/vaam-store/image-resizer/issues/62)).
+
+## Tooling and CI
+
+- A real CI pipeline: a per-feature-set test matrix (`local_fs`, `s3`,
+  `local_fs,otel`), Clippy, `cargo-deny`, and the benchmark regression
+  gate above - previously only a Docker build and a linter ran at all
+  (epic [#9](https://github.com/vaam-store/image-resizer/issues/9),
+  [#46](https://github.com/vaam-store/image-resizer/issues/46)).
+- A docs/env-var drift check (`.github/scripts/check_env_docs.py`) fails
+  CI if `src/modules/env/env.rs` and
+  [Configuration](../getting-started/configuration.md) disagree in
+  either direction ([#47](https://github.com/vaam-store/image-resizer/issues/47)).
+- A Knative Serverless Helm chart (`helm/serverless/`) added alongside
+  the Deployment-based chart (`helm/emgr/`), for scale-to-zero setups.
+- A `PodDisruptionBudget` and liveness/readiness/startup probes added to
+  the Deployment Helm chart - previously a voluntary disruption could
+  evict every replica at once, and a wedged container was never
+  restarted ([#48](https://github.com/vaam-store/image-resizer/issues/48)).
+- ADRs recording the image-engine choice, the URL/API shape, and
+  measurement writeups for the WebP and AVIF encoder decisions
+  (`adr/0001` through `adr/0004`).

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,3 +1,10 @@
+# License
+
+`emgr` is licensed under the MIT License. The full text below is
+reproduced from the repository's [`LICENSE`](https://github.com/vaam-store/image-resizer/blob/main/LICENSE)
+file.
+
+```text
 MIT License
 
 Copyright (c) 2025 Stephane SEGNING LAMBOU
@@ -19,3 +26,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+## Third-party notices
+
+`emgr` links native code with its own licenses and attribution
+obligations, reproduced from the repository's
+[`NOTICE`](https://github.com/vaam-store/image-resizer/blob/main/NOTICE)
+file:
+
+- **mozjpeg** (via the `mozjpeg`/`mozjpeg-sys` crates, used for DCT-scaled
+  and full-size JPEG decoding and for JPEG encoding - see the
+  [changelog](changelog.md#performance)) vendors libjpeg-turbo and
+  Independent JPEG Group (IJG) code, distributed under the IJG, Zlib and
+  BSD-3-Clause licenses. Per the IJG license, this software is based in
+  part on the work of the Independent JPEG Group.
+- **libwebp** (via the `webp` crate, BSD-3-Clause) is used for lossy WebP
+  encoding.
+
+Full license texts for every dependency ship with those crates and are
+reproduced in the dependency tree under `~/.cargo/registry` (or your
+project's vendored `Cargo.lock`-resolved sources). `cargo-deny`'s
+`licenses` check (`deny.toml`, run in CI) enforces that every dependency's
+declared license is one this project allows - see
+[Contributing](../development/contributing.md) for running it locally.

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1,143 +1,232 @@
 # Components
 
-This page provides detailed information about the key components of the Image Resize Service.
+This page maps every real module under `src/` to what it does. It is a companion to
+`overview.md`, which covers the request flow, the redirect-based delivery trade-off, and the two
+required diagrams. Every module and file path below was checked against the code on `main`,
+not assumed from names.
 
-## API Module
+## Entry point
 
-The API module (`src/modules/api/`) handles the HTTP API interface and parameter validation.
+### `src/main.rs`
 
-### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Request handlers
-- `resize.rs`: Resize API implementation
+Builds the Tokio runtime by hand (not `#[tokio::main]`) so `worker_threads` can be a runtime
+value read from `TOKIO_WORKER_THREADS`, cgroup-aware via `modules::utils::cgroup::effective_cpu_count`
+rather than `num_cpus::get()` directly (a cgroup-limited container otherwise oversizes the
+runtime for the host's full core count). Sets `mimalloc::MiMalloc` as the global allocator.
+Installs a SIGTERM/SIGINT-triggered graceful shutdown with a configurable drain deadline
+(`SHUTDOWN_TIMEOUT_SECS`, default 20s — comfortably under Kubernetes' default 30s
+`terminationGracePeriodSeconds`).
 
-The API module is responsible for:
-- Parsing and validating request parameters
-- Converting API requests to service calls
-- Formatting service responses as API responses
-- Error handling and response codes
+### `src/bin/healthcheck.rs`, `src/bin/benchmark.rs`
 
-## Router Module
+Two extra binaries: a standalone healthcheck probe, and a load-generating benchmark client
+(serves fixture images locally and drives the resize endpoint against them — see
+`.bench-baseline/BASELINE.md` for how its output feeds the performance numbers cited in
+`overview.md`).
 
-The Router module (`src/modules/router/`) manages HTTP routing and middleware.
+## Router and middleware — `src/modules/router/`
 
-### Key Files:
-- `mod.rs`: Module definition
-- `router.rs`: Route definitions
-- `middlewares.rs`: HTTP middleware implementations
+- **`router.rs`** — hand-written route table (`build_app`): `GET /health` (unauthenticated,
+  Kubernetes probe target), `GET /api/images/files/{key}` (unsigned download route),
+  `GET /{signature}/{*rest}` (the imgproxy-compatible signed resize route, mounted at the root —
+  axum/matchit prefers a literal path segment like `api`/`health` over this route's dynamic first
+  segment, so it never shadows the others), and, only when built with `--features otel`,
+  `GET /metrics` behind `metrics_auth::require_metrics_auth`. There is no `gen_server`-generated
+  router anywhere in this file or this codebase — see "Removed" below.
+- **`middlewares.rs`** — `MiddlewareConfig` (env-driven: `REQUEST_TIMEOUT_SECS`,
+  `MAX_CONCURRENT_REQUESTS`, `RATE_LIMIT_BURST`, `RATE_LIMIT_PERIOD_MS`) plus
+  `apply_common_middlewares`, which layers, outer to inner: CORS, `tower_governor`'s per-IP
+  token-bucket `GovernorLayer` (429 on excess — its per-key state is pruned every 60s via
+  `limiter.retain_recent()` so it doesn't grow unbounded over the process lifetime), a conditional-
+  GET middleware for the download route (`ETag`/`If-None-Match`/`304`, computed directly from the
+  requested key without touching storage), a `Semaphore`-backed saturation/timeout guard (503 on
+  either), and `tower-http`'s `CompressionLayer` (br/deflate/gzip/zstd) closest to the app.
 
-The Router module is responsible for:
-- Defining API routes
-- Applying middleware (logging, tracing, etc.)
-- Request/response handling
+## API handlers — `src/modules/api/`
 
-## Services
+- **`handler.rs`** — `ApiService`, the shared application state: `resize_service`, `signing`,
+  `presets`/`allowed_options` (issue #52), and (under `otel`) `metrics_auth`. `ApiService::create`
+  builds every sub-config from `EnvConfig` and fails closed at startup for signing, `/metrics` auth,
+  and preset parsing — a misconfiguration is a boot-time error, not a per-request surprise.
+- **`resize.rs`** — `GET /{signature}/{processing_options}/{plain|base64 source}.{extension}`.
+  Splits the path (`modules::url::split`), verifies the signature, parses options+source
+  (`SignedRequest::parse_with_config`), resolves `.auto` via `modules::negotiation::resolve`, calls
+  `ResizeService::resize`, and builds an explicit `301` (not axum's `Redirect::permanent`, which
+  issues `308`) with `Cache-Control: public, max-age=31536000, immutable` and, only for a negotiated
+  `.auto` request, `Vary: Accept`.
+- **`download.rs`** — `GET /api/images/files/{key}`, deliberately unsigned (this route only ever
+  serves bytes the resize route already produced and cached under a content-derived key; the strict
+  key grammar in `services::storage::key_validation` is the guard here, not a signature). Derives
+  `Content-Type` from the key's own extension.
 
-### Resize Service
+## URL grammar and signing
 
-The Resize Service (`src/services/resize/`) handles image resizing operations.
+### `src/modules/url/`
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Resize implementation
+Implements the imgproxy-compatible signed-URL grammar
+`/{signature}/{processing_options}/{plain|base64 source}.{extension}`:
 
-The Resize Service is responsible for:
-- Processing resize parameters
-- Applying resize operations to images
-- Handling different resize modes (fit, cover, etc.)
+- **`mod.rs`** — `split` (cheap extraction of the signature segment and the exact signed byte
+  string, run before any full parse so an unauthenticated caller can't use parse-error content as
+  an oracle) and `SignedRequest::parse`/`parse_with_config` (full options+source grammar, presets
+  and the processing-option allowlist applied ahead of the plain grammar parse).
+- **`options.rs`** — `ProcessingOptions`, parsing `/`-delimited `code:arg1:arg2` segments (`rs`,
+  `q`, `bl`, `g`, `el`, `fq`, `webpo`, crop/gravity, rotate/flip/trim/extend/padding/zoom/dpr/
+  min-width/min-height, watermark, preset references).
+- **`presets.rs`** — `PresetRegistry` (parses the `PRESETS` env var: named, reusable option-segment
+  lists, imgproxy-compatible; a preset named `default` is auto-prepended to every request) and
+  `AllowedOptions` (parses `ALLOWED_PROCESSING_OPTIONS`, an allowlist of which option codes a
+  deployment permits at the top level of a URL).
+- **`source.rs`** — `SourceSpec`/`parse_source`: either `plain/{percent-encoded URL}.{extension}`
+  or a single base64url-encoded segment, with the trailing `.{extension}` mandatory and mapped to
+  `ImageFormat` (including the `.auto` negotiation trigger).
 
-### Image Service
+### `src/modules/signing/`
 
-The Image Service (`src/services/image/`) handles image processing and manipulation.
+- **`verify.rs`** — `compute_signature`/`verify_signature`/`sign`: `HMAC-SHA256(key, salt ||
+  signed_path)`, base64url (no padding), constant-time comparison via the `subtle` crate.
+- **`config.rs`** — `SigningConfig::from_env`, which fails closed at startup (issue #27): a
+  deployment must either configure a real key/salt or explicitly set
+  `ALLOW_UNSIGNED_REQUESTS=true` to use the `/unsigned/...` escape hatch.
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Image processing implementation
+### `src/modules/negotiation.rs`
 
-The Image Service is responsible for:
-- Loading images from various sources
-- Image format conversion
-- Image quality adjustments
+`resolve(format, accept)` — resolves `ImageFormat::Auto` against the request's `Accept` header,
+preferring AVIF, then WebP, falling back to JPEG, weighted by each entry's `q` parameter. Any
+non-`Auto` format passes through unchanged with `negotiated = false`.
 
-### Storage Service
+### `src/modules/metrics_auth/`
 
-The Storage Service (`src/services/storage/`) provides a unified interface for different storage backends.
+Bearer-token authentication for `GET /metrics` (issue #77), gated behind the `otel` feature since
+that's the only build where `/metrics` is ever mounted at all. `MetricsAuthConfig::from_env` fails
+closed at startup, mirroring `SigningConfig`.
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `core.rs`: Storage trait definitions
-- `handler.rs`: Storage implementation
-- `s3_handler.rs`: S3 storage implementation
-- `local_fs_handler.rs`: Local filesystem implementation
-- `in_memory_handler.rs`: In-memory storage implementation
+## Services — `src/services/`
 
-The Storage Service is responsible for:
-- Storing and retrieving images
-- Managing storage backends
-- Handling storage errors
+### `resize/handler.rs` — `ResizeService`
 
-### Cache Service
+The orchestrator tying cache, image processing, and storage together:
 
-The Cache Service (`src/services/cache/`) provides caching functionality.
+- `resize(params)` — generates the cache key, checks the cache, and on a miss runs
+  single-flight coalescing before calling `do_resize_work`. See `overview.md`'s "Concurrency
+  model" and its cache-miss sequence diagram for the full mechanics of `InFlightMap`/`InFlightGuard`
+  (issue #37).
+- `do_resize_work` — the actual download → process → upload pipeline for a confirmed miss.
+- `download(params)` — serves the unsigned `/api/images/files/{key}` route by reading directly
+  from storage; a missing/expired key surfaces as a "not found" message that
+  `AppError::classify_download_error` maps to `404`.
+- `resize_batch` — bounded-concurrency batch resizing over `futures::stream::buffer_unordered`.
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Cache implementation
+### `image/handler.rs` — `ImageService`
 
-The Cache Service is responsible for:
-- Caching processed images
-- Cache invalidation
-- Cache hit/miss metrics
+Owns the two semaphores (`download_semaphore`, `processing_semaphore`), the SSRF-guarded fetch
+path, and the decode/resize/encode pipeline:
 
-### Health Service
+- `fetch_validated`/`download_image` — see `overview.md`'s "Security boundary" section for the
+  SSRF guard itself (implemented in `source_guard.rs`, described next). `download_image` also
+  enforces the streaming size cap.
+- `process_image` — acquires `processing_semaphore` (non-blocking `try_acquire_owned`, `503` on
+  exhaustion) and runs decode/resize/encode on `spawn_blocking`, with a `tx.is_closed()` check to
+  skip queued-but-not-yet-started work when the caller has already disconnected.
+- `process_image_blocking_with_limits*` — header-only dimension peek and resolution check
+  (decompression-bomb guard) before any full decode; EXIF autorotate, trim, and explicit crop are
+  applied in that order (matching imgproxy's own pipeline ordering) before the actual resize;
+  animated GIF/WebP sources are detected and routed to `encode_animation` separately.
+- `decode_with_limits`/`decode_jpeg_scaled` — mozjpeg-first JPEG decode (DCT-scaled when a resize
+  makes a smaller decode safe), falling back to the `image`-crate decoder (`decode_with_image_crate`,
+  also the only path for PNG/WebP) on any mozjpeg failure.
+- `encode_with_max_bytes` — binary-searches JPEG quality down until encoded output fits a
+  requested `max_bytes` budget (issue #76), bounded to a fixed number of extra encode attempts.
 
-The Health Service (`src/services/health/`) monitors system health.
+### `image/source_guard.rs`
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Health check implementation
+Pure, deterministic SSRF validation logic (the one exception is `resolve_validated_addr`, which
+performs the actual DNS lookup): `validate_scheme`, `is_allowed_source`/`matches_allowed_prefix`,
+`is_blocked_ip_with_policy` (and its IPv4/IPv6 halves), and IPv4-literal decoding covering
+decimal/octal/hex smuggling forms. See `overview.md`'s "Security boundary" for the full threat
+model this covers and why redirect revalidation and DNS pinning are both necessary.
 
-The Health Service is responsible for:
-- Providing health check endpoints
-- Monitoring system components
-- Reporting system status
+### `cache/handler.rs` — `CacheService`
 
-### Metrics Service
+`generate_key(params)` — the SHA-256, length-prefixed, versioned cache key described in
+`overview.md`'s "Cache key design". `CACHE_KEY_VERSION` is currently `9`; its doc comment on this
+file is the authoritative history of what each version bump added and, in one case (issue #67),
+why a bump was deliberately *not* taken.
 
-The Metrics Service (`src/services/metrics/`) collects and exposes metrics.
+### `storage/`
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `handler.rs`: Metrics implementation
+- **`core.rs`** — the `StorageBackend` trait: `upload_image`/`upload_image_with_ttl`,
+  `check_cache`, `get_image`, `delete`. `ttl: None` means "never expires."
+- **`handler.rs`** — `StorageService`/`StorageConfig`/`StorageType`, selecting a backend by Cargo
+  feature and (when more than one is compiled in) `STORAGE_TYPE`. Also enforces that a configured
+  `key_prefix` (from `STORAGE_SUB_PATH`) matches what `CacheService::generate_key` actually
+  produces.
+- **`s3_handler.rs`** (feature `s3`) — S3/MinIO-compatible backend via `aws-sdk-s3`.
+- **`local_fs_handler.rs`** (feature `local_fs`) — local-directory backend.
+- **`in_memory_handler.rs`** (feature `in_memory`, test-only) — unbounded `HashMap`-backed
+  backend, `#[cfg(all(test, feature = "in_memory"))]` — does not exist in a release build at all,
+  regardless of the Cargo feature flag; selecting it via `STORAGE_TYPE` outside tests fails fast at
+  startup instead of running an uncapped cache in production.
+- **`key_validation.rs`** — `validate_cache_key`, the strict grammar
+  (`<prefix><64 lowercase hex>.<jpg|png|webp|avif|gif>`) every backend is checked against before a
+  key ever reaches it, closing path-traversal and S3 IDOR in one place rather than per backend.
 
-The Metrics Service is responsible for:
-- Collecting performance metrics
-- Exposing Prometheus-compatible metrics
-- Monitoring system usage
+### `health/handler.rs`
 
-## Utility Modules
+`health()` — returns the literal string `"OK"`. Deliberately unauthenticated; see
+`overview.md`'s "Security boundary" for why.
 
-### Tracer Module
+### `metrics/handler.rs`
 
-The Tracer Module (`src/modules/tracer/`) provides distributed tracing functionality.
+`metrics_handler()` — encodes the global Prometheus registry (`prometheus::gather()`) as text.
+Only compiled/mounted under the `otel` feature; protected by `modules::metrics_auth` at the router
+layer, not in this handler itself.
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `init.rs`: Tracer initialization
+## Models — `src/models/params.rs`
 
-### Utils Module
+`ResizeQuery` (the fully-parsed representation of a resize request — url, width/height,
+`ResizeType`, `ImageFormat`, quality/format-quality overrides, crop/gravity, geometry operations,
+watermark, etc.) and `DownloadPathParams` (`{ key: String }`, hand-written — see "Removed" below).
 
-The Utils Module (`src/modules/utils/`) provides utility functions.
+## Configuration
 
-#### Key Files:
-- `mod.rs`: Module definition
-- `date.rs`: Date/time utilities
-- `err.rs`: Error handling utilities
+- **`src/modules/env/env.rs`** — `EnvConfig`, the `envconfig`-derived top-level environment
+  binding (HTTP host/port, storage credentials, `MAX_IMAGE_SIZE_MB`, `MAX_SRC_RESOLUTION_MP`,
+  `ALLOWED_SOURCES`, `ALLOW_LOOPBACK_SOURCE_ADDRESSES`/`ALLOW_LINK_LOCAL_SOURCE_ADDRESSES`,
+  `max_redirects`, presets/allowlist strings, etc.).
+- **`src/config/performance.rs`** — `PerformanceConfig`, derived from `EnvConfig` plus a small set
+  of named default profiles (default/high-throughput/low-latency/memory-constrained), each setting
+  `max_image_size`, `max_src_resolution_mp`, `max_redirects`, download/processing concurrency
+  limits, and the SSRF-guard override flags.
 
-## Models
+## Utility modules — `src/modules/utils/`
 
-The Models (`src/models/`) define data structures used throughout the application.
+- **`date.rs`** — a minimal hand-rolled RFC 7231 `IMF-fixdate` formatter (no date/time crate is a
+  dependency of this crate), used for the download route's `Last-Modified` header.
+- **`etag.rs`** — `if_none_match_satisfied`, RFC 7232 §3.2 strong-comparison matching against the
+  single server-computed `ETag` the conditional-download middleware produces.
+- **`err.rs`** — `AppError` and its `classify_download_error`/`classify_resize_error`
+  constructors, mapping internal failures to HTTP status codes (see `overview.md`'s rejection-state
+  diagram for the concrete mapping). Every variant renders with `Cache-Control: no-store`.
+- **`cgroup.rs`** — `effective_cpu_count`, reading cgroup v2 `cpu.max` or cgroup v1
+  `cpu.cfs_quota_us`/`cpu.cfs_period_us` directly (falling back to `num_cpus::get()`), used by
+  `main.rs` to size the Tokio runtime.
 
-### Key Files:
-- `mod.rs`: Module definition
-- `params.rs`: API parameter definitions
+## Tracing — `src/modules/tracer/`
+
+OpenTelemetry tracing/metrics initialization (`init.rs`), compiled only under the `otel` feature.
+
+## Removed since the last documentation pass
+
+The following existed in an earlier version of this service and no longer do. They are recorded
+here only as history, not as current architecture:
+
+- **The generated OpenAPI server** (`gen-server`, a `packages/` directory, `openapi.yaml`). Issue
+  #53 replaced it with the hand-written router in `src/modules/router/router.rs` and the
+  hand-written handlers in `src/modules/api/`. Verified: `grep -rc 'gen-server\|gen_server\|openapi'
+  Cargo.toml` and `find . -iname 'openapi.yaml'` both return nothing in this tree.
+- **`rayon`** — the old CPU-bound processing pool. Replaced by `tokio::task::spawn_blocking`
+  bounded by `processing_semaphore`; see `image/handler.rs`'s doc comment on `process_image` for
+  why rayon's intra-job work-stealing was never actually used. Not a dependency in `Cargo.toml`.
+- **`o2o`**, **`lru`**, **`axum-extra`** — none appear in `Cargo.toml`'s dependency list; no code
+  under `src/` references them.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,75 +1,277 @@
 # Architecture Overview
 
-The Image Resize Service is designed with a modular architecture to provide high performance, scalability, and flexibility.
+`emgr` is an imgproxy-compatible image resizing/transcoding service written in Rust. A client
+requests a resized image via a signed URL; on a cache miss `emgr` fetches the source, processes it,
+writes the result to object storage, and redirects the client there. On a cache hit it skips
+straight to the redirect. This redirect-based delivery model is the single most consequential
+design decision in the system (see "Redirect-based delivery" below) and shapes almost everything
+else documented here and in `docs/architecture/components.md`.
 
-## High-Level Architecture
+This file describes the system as it exists on `main` today. For component-by-component detail
+(which module owns what, which files back which behaviour), see `components.md`.
 
+## Request flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant emgr as emgr (resize_handler)
+    participant Cache as Storage (cache check)
+    participant Guard as SSRF guard
+    participant Origin as Source origin
+    participant Storage as Storage backend
+
+    Client->>emgr: GET /{signature}/{options}/{source}.{ext}
+    Note over emgr: src/modules/router/router.rs:48<br/>route "/{signature}/{*rest}"
+    emgr->>emgr: url::split + verify_signature<br/>(src/modules/api/resize.rs:45-47,<br/>src/modules/signing/verify.rs:31)
+    emgr->>emgr: SignedRequest::parse_with_config<br/>(src/modules/url/mod.rs)
+    emgr->>emgr: CacheService::generate_key<br/>(src/services/cache/handler.rs:139)
+    emgr->>Cache: check_cache(key)<br/>(src/services/resize/handler.rs:183)
+    alt cache hit
+        Cache-->>emgr: true
+        emgr-->>Client: 301 Location: storage/key<br/>(src/modules/api/resize.rs:139)
+    else cache miss
+        Cache-->>emgr: false
+        emgr->>emgr: become single-flight leader<br/>(src/services/resize/handler.rs:205-233)
+        emgr->>Guard: fetch_validated(source url)<br/>(src/services/image/handler.rs:173)
+        Guard->>Guard: scheme + allowlist + resolve_validated_addr<br/>(src/services/image/source_guard.rs:147,180,356)
+        Guard->>Origin: GET (pinned to validated addr)
+        Origin-->>Guard: image bytes (streamed, size-capped)
+        Guard-->>emgr: Bytes
+        emgr->>emgr: spawn_blocking: decode/resize/encode<br/>(src/services/image/handler.rs:407, 622)
+        emgr->>Storage: upload_image_with_ttl(key, bytes)<br/>(src/services/resize/handler.rs:281)
+        Storage-->>emgr: ok
+        emgr-->>Client: 301 Location: storage/key<br/>(src/modules/api/resize.rs:139)
+    end
+    Client->>Storage: GET storage/key (second round trip)
+    Storage-->>Client: image bytes
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Client    │────▶│  API Layer  │────▶│  Services   │
-└─────────────┘     └─────────────┘     └─────────────┘
-                          │                    │
-                          ▼                    ▼
-                    ┌─────────────┐     ┌─────────────┐
-                    │   Router    │     │   Storage   │
-                    └─────────────┘     └─────────────┘
-                                              │
-                                              ▼
-                                        ┌─────────────┐
-                                        │    Cache    │
-                                        └─────────────┘
+
+Cache hit and cache miss both end in the same `301 Moved Permanently` redirect
+(`src/modules/api/resize.rs:139`) to a URL under `StorageConfig::cdn_base_url` — never a redirect
+back to the caller-supplied source (deliberately: that used to be an open redirect from a trusted
+domain, and 301s are cached permanently by browsers, so a transient origin failure would have
+permanently steered clients away — see the comment at `src/modules/api/resize.rs:77`). The
+difference between hit and miss is entirely in what happens *before* that redirect is built.
+
+## Redirect-based delivery: the central trade-off
+
+`emgr` never streams processed image bytes back to the client on the same connection. Both a
+cache hit and a freshly-processed cache miss end the request with a `301` pointing at the object
+in storage (local filesystem, S3, or in-memory-for-tests — see "Storage backends" below); the
+client then makes a second request to fetch the actual bytes. imgproxy, by contrast, streams the
+processed image directly on the original connection and has no server-side result cache at all —
+every request is reprocessed from scratch.
+
+This is not an incidental implementation detail; it is the architectural choice that produces both
+`emgr`'s strongest and weakest measured numbers, from `.bench-baseline/BASELINE.md`'s "Post-#67
+baseline" (2026-08-21, `local_fs` backend, medians of 3 runs):
+
+| Path | emgr (local_fs) | imgproxy | Ratio |
+|---|---:|---:|---:|
+| Cold (cache miss), p50 | 66.82 ms | 20.50 ms | emgr 3.26x **slower** |
+| Warm (cache hit), p50 | 0.39 ms | 20.10 ms | emgr 51x **faster** |
+
+- **Cold path cost.** A cache miss pays for *two* HTTP round trips per delivered image
+  (`req/image = 2.00` in the baseline table) instead of imgproxy's one: the client requests the
+  resize, gets a 301, and re-fetches from storage. Part of the 66.82 ms is genuine decode/resize/
+  encode work, but part of it is this two-hop delivery shape itself — the same shape that makes the
+  warm path so cheap.
+- **Warm path payoff.** A cache hit costs a single `check_cache` lookup (`src/services/resize/
+  handler.rs:183`) and a redirect — no decode, no resize, no encode. `emgr` never touches the image
+  pipeline for a repeat request; imgproxy has no equivalent and reprocesses every single request,
+  identical bytes or not.
+- **The trade is inherent, not a bug to fix.** The cold penalty cannot be removed without giving up
+  the warm win — they are the same architecture viewed from two angles. Which one dominates in
+  practice depends on production cache-hit rate, a number neither benchmark measures
+  (`.bench-baseline/BASELINE.md`, "Where the remaining cold gap lives").
+- In production, imgproxy is normally deployed behind an external CDN that would absorb repeat
+  requests the way `emgr`'s built-in cache does natively — so the honest framing is "`emgr`'s
+  built-in result cache vs. imgproxy's reliance on an external one," not "`emgr` processes images
+  faster" (it measurably does not, cold: 3.26x slower).
+
+## Storage backends
+
+Three backends implement a common `StorageBackend` trait (`src/services/storage/core.rs`), selected
+by Cargo feature and, when more than one is compiled in, by the `STORAGE_TYPE` environment variable
+(`src/services/storage/handler.rs:42-141`):
+
+- **`local_fs`** (`src/services/storage/local_fs_handler.rs`) — writes to a local directory.
+- **`s3`** (`src/services/storage/s3_handler.rs`) — S3-compatible object storage (MinIO-tested).
+- **`in_memory`** (`src/services/storage/in_memory_handler.rs`) — an unbounded `HashMap`, gated
+  `#[cfg(all(test, feature = "in_memory"))]`. It does not exist in a release build regardless of
+  whether the `in_memory` Cargo feature is enabled — selecting `STORAGE_TYPE=IN_MEMORY` in
+  production fails fast at startup instead of running an unbounded, uncapped cache. It exists purely
+  to exercise `StorageBackend` in this crate's own tests.
+
+The trait also carries an optional per-entry TTL (`upload_image_with_ttl`); `None` means "never
+expires," the only behaviour available before TTL support existed, and still the default —
+`ResizeService` has no config knob feeding a real duration into it today (`src/services/resize/
+handler.rs:139-146`).
+
+## Concurrency model
+
+- **`tokio` async I/O** throughout, with the runtime's worker-thread count configurable
+  (`TOKIO_WORKER_THREADS`, cgroup-aware default — `src/main.rs:33-51`).
+- **CPU-bound work on `spawn_blocking`.** Decode/resize/encode runs on tokio's managed blocking
+  thread pool, not a hand-rolled `rayon` pool — `rayon`'s value proposition is intra-job work-
+  stealing parallelism, and nothing in this pipeline fans a single image's work out across threads
+  (`src/services/image/handler.rs:327-345`). `rayon` is not a dependency of this crate.
+- **Two independent semaphores** bound in-flight work: `download_semaphore` caps concurrent source
+  fetches, `processing_semaphore` caps concurrent CPU-bound decode/resize/encode jobs
+  (`src/services/image/handler.rs:96-105`). Both shed load with an error rather than queue when
+  exhausted.
+- **Single-flight coalescing.** Once a cache miss is confirmed, concurrent requests for the same
+  cache key share one leader's work instead of each downloading/processing/uploading independently
+  (`src/services/resize/handler.rs:29-127`, issue #37). An `RAII` guard broadcasts the leader's
+  result (or a synthetic failure, if the leader panics or is cancelled) to every follower via a
+  `tokio::sync::broadcast` channel, so followers can never hang indefinitely.
+- **Router-level saturation shedding and rate limiting** (`src/modules/router/middlewares.rs`):
+  a `tokio::sync::Semaphore`-based concurrency cap plus request timeout
+  (`saturation_and_timeout_middleware`, `503` on exhaustion), and per-IP token-bucket rate limiting
+  via `tower_governor` (`429 Too Many Requests` on excess).
+
+## Security boundary
+
+- **HMAC-SHA256 signed URLs** (`src/modules/signing/`), imgproxy-compatible
+  (`HMAC-SHA256(key, salt || signed_path)`, constant-time comparison). Signing configuration fails
+  closed at process startup (`SigningConfig::from_env`) rather than silently accepting unsigned
+  traffic if misconfigured — an explicit `ALLOW_UNSIGNED_REQUESTS=true` opt-in is required to use
+  the `/unsigned/...` escape hatch for local development.
+- **SSRF guard** (`src/services/image/source_guard.rs`) applied to every source fetch (and every
+  watermark fetch, which reuses the same guarded path):
+  - Scheme allowlist: only `http`/`https` (`validate_scheme`).
+  - Optional `ALLOWED_SOURCES` prefix allowlist, matched structurally (parsed scheme/host/port/path
+    segments, never raw-text `starts_with`) to close userinfo-spoofing and subdomain-boundary
+    bypasses (`is_allowed_source`, `matches_allowed_prefix`).
+  - Private/loopback/link-local/CGNAT/IPv6-ULA range blocking, including decimal/octal/hex IPv4
+    literal decoding (`is_blocked_ip_with_policy`, `parse_ip_literal`), independently toggleable via
+    `ALLOW_LOOPBACK_SOURCE_ADDRESSES`/`ALLOW_LINK_LOCAL_SOURCE_ADDRESSES`.
+  - **DNS-rebinding pinning:** the address is resolved and validated once, then the HTTP client is
+    pinned to that exact `SocketAddr` for the connection (`build_pinned_client`) — a second,
+    attacker-controlled DNS answer at connect time can never be observed.
+  - **Per-hop redirect revalidation:** redirects are followed manually (`reqwest`'s own redirect
+    handling is disabled), and every check above re-runs for each hop's new location
+    (`fetch_validated`, `src/services/image/handler.rs:173-234`) — an `ALLOWED_SOURCES` match is
+    recomputed per hop, so a bypass on one allowlisted host never carries over to a redirect target
+    that doesn't independently match.
+- **Streaming download size cap.** `Content-Length` is checked as a cheap early rejection, but the
+  real enforcement streams the body and aborts once the running total exceeds the cap — closing the
+  gap a dishonest origin or chunked transfer encoding (no `Content-Length`) would otherwise leave
+  open (`download_image`, `src/services/image/handler.rs:281-317`).
+- **Decompression-bomb guard.** Image dimensions are read from the header only
+  (`peek_dimensions`/`ImageReader::into_dimensions`) and checked against `MAX_SRC_RESOLUTION_MP`
+  *before* any full decode is attempted, so a small-on-disk/huge-decoded source is rejected without
+  ever allocating the decoded buffer (`src/services/image/handler.rs:2669-2682`, `process_image_
+  blocking_with_limits`).
+- **Strict storage-key grammar** (`src/services/storage/key_validation.rs`) rejects any key that
+  doesn't match exactly what `CacheService::generate_key` can produce, closing IDOR/traversal
+  against both the download route and every storage backend.
+- **`/metrics` bearer-token auth** (`src/modules/metrics_auth/`), gated behind the `otel` feature,
+  fails closed at startup the same way signing does. `/health` is deliberately left unauthenticated
+  — it is the target of Kubernetes liveness/readiness/startup probes, which have no practical way to
+  carry a bearer token, and it only ever returns the literal string `"OK"`.
+
+## Codec choices
+
+- **JPEG decode and encode** go through `mozjpeg` (libjpeg-turbo bindings), not the `image` crate's
+  pure-Rust path — DCT-scaled decode when a resize makes a smaller decode safe, full-size decode
+  otherwise, with a fallback to the `image`-crate decoder on any mozjpeg failure. See `adr/0001-
+  image-engine.md` for the original engine decision and `.bench-baseline/BASELINE.md`'s "Post-#67
+  baseline" for the measured decode-side numbers.
+- **Resampling** uses the `fast_image_resize` crate rather than `image`'s own `DynamicImage::resize`
+  kernel — several times faster at equivalent measured quality (DSSIM); see `.bench-baseline/
+  BASELINE.md`'s "Current baseline" section.
+- **WebP** encode/decode goes through the `webp` crate (real lossy libwebp), not the `image` crate's
+  lossless-only WebP encoder. See `adr/0001-image-engine.md` (original rationale) and `adr/0003-
+  webp-measurement.md` (corrected byte-size measurement on real photos).
+- **AVIF is encode-only.** See `adr/0004-avif-measurement.md` for the byte-size/encode-time
+  measurement this decision is based on.
+
+## Cache key design
+
+`CacheService::generate_key` (`src/services/cache/handler.rs`) hashes a version byte followed by
+every resize-affecting parameter, each **length-prefixed** rather than delimiter-separated:
+`hasher.update(len_be_bytes); hasher.update(field_bytes)` per field. This matters because `url` is
+fully attacker-controlled — a fixed delimiter byte (e.g. `|` or `\0`) could appear inside the URL
+itself and be used to forge a byte stream that collides with a different, legitimate parameter
+combination. A 4-byte big-endian length prefix makes every field boundary unambiguous regardless of
+the field's own content, so the mapping from `(field_1, .., field_n)` to the hashed stream is
+injective. The leading version byte (currently `9`) is bumped whenever the hashed layout or the
+encoder/decoder producing the cached bytes changes in a way that would otherwise let old and new
+entries collide or serve stale output — see the version history documented directly in that file's
+`CACHE_KEY_VERSION` doc comment, including a case where a bump was deliberately *not* taken (issue
+#67's decoder swap) because the output was measured perceptually identical and a bump would have
+forced a full reprocessing storm for zero visible benefit.
+
+## Request lifecycle, including rejections
+
+```mermaid
+stateDiagram-v2
+    [*] --> PathReceived: GET /{signature}/{*rest}<br/>src/modules/router/router.rs:48
+
+    PathReceived --> RateLimited: over per-IP burst<br/>tower_governor, src/modules/router/middlewares.rs:292
+    RateLimited --> [*]: 429 Too Many Requests
+
+    PathReceived --> Saturated: concurrency cap exceeded<br/>src/modules/router/middlewares.rs:119-135
+    Saturated --> [*]: 503 service at capacity
+
+    PathReceived --> SplitPath: url::split<br/>src/modules/url/mod.rs:73
+    SplitPath --> BadGrammar: malformed path
+    BadGrammar --> [*]: 400 Bad Request<br/>src/modules/api/resize.rs:129 (url_parse_error)
+
+    SplitPath --> VerifySignature: verify_or_reject<br/>src/modules/api/resize.rs:90
+    VerifySignature --> BadSignature: missing/wrong signature,<br/>or unsigned not allowed
+    BadSignature --> [*]: 403 Forbidden<br/>src/modules/api/resize.rs:95,105,118
+
+    VerifySignature --> ParseOptions: SignedRequest::parse_with_config<br/>src/modules/url/mod.rs
+    ParseOptions --> BadOptions: unknown/disallowed option,<br/>bad value, unknown preset
+    BadOptions --> [*]: 400 Bad Request
+
+    ParseOptions --> CacheKeyed: CacheService::generate_key
+    CacheKeyed --> CacheHit: check_cache = true<br/>src/services/resize/handler.rs:183
+    CacheHit --> [*]: 301 redirect to storage
+
+    CacheKeyed --> SingleFlight: check_cache = false
+    SingleFlight --> Fetching: this caller is leader<br/>src/services/resize/handler.rs:205-233
+
+    Fetching --> SsrfBlocked: scheme/allowlist/IP-range<br/>rejected, src/services/image/source_guard.rs
+    SsrfBlocked --> [*]: 400 Bad Request<br/>(SourceRejected downcast,<br/>src/modules/utils/err.rs:109-115)
+
+    Fetching --> OversizedSource: streamed size exceeds<br/>MAX_IMAGE_SIZE_MB, src/services/image/handler.rs:281-317
+    OversizedSource --> [*]: 400 Bad Request<br/>("too large", src/modules/utils/err.rs:120-124)
+
+    Fetching --> Decoding: source fetched
+    Decoding --> OverResolutionSource: header-only dimension check<br/>fails MAX_SRC_RESOLUTION_MP,<br/>src/services/image/handler.rs:2669-2682
+    OverResolutionSource --> [*]: 400 Bad Request<br/>("too large", src/modules/utils/err.rs:120-124)
+
+    Decoding --> Processing: spawn_blocking decode/resize/encode<br/>src/services/image/handler.rs:407,622
+    Processing --> Uploading: upload_image_with_ttl<br/>src/services/resize/handler.rs:281
+    Uploading --> Delivered: 301 redirect to storage
+    Delivered --> [*]
+
+    SingleFlight --> Following: another caller is leader
+    Following --> Delivered: leader's broadcast result
+    Following --> LeaderFailed: leader panicked/cancelled
+    LeaderFailed --> [*]: error propagated from leader's failure
 ```
 
-## Key Components
+Every rejection state above maps to a non-cacheable response (`Cache-Control: no-store`,
+`src/modules/utils/err.rs`) — a cached error is worse than an uncached one, since a CDN or client
+would otherwise treat a transient failure as permanent.
 
-### API Layer
+## Technology stack
 
-The API layer handles incoming HTTP requests, validates parameters, and routes requests to the appropriate service.
+- **Language:** Rust (2024 edition).
+- **Web framework:** `axum`, with `tower_governor` for rate limiting and `tower-http` for
+  compression/CORS.
+- **Image processing:** `image` (container formats, PNG/GIF/AVIF paths), `mozjpeg` (JPEG decode +
+  encode), `fast_image_resize` (resampling), `webp` crate (lossy WebP).
+- **Storage:** `aws-sdk-s3` (S3/MinIO), local filesystem, in-memory (test-only).
+- **Observability:** OpenTelemetry tracing/metrics behind the `otel` Cargo feature
+  (`src/modules/tracer/`), Prometheus-format `/metrics` behind bearer-token auth.
+- **Allocator:** `mimalloc` as the global allocator (`src/main.rs`).
 
-### Router
-
-The router manages HTTP routing, middleware integration, and request/response handling.
-
-### Services
-
-The service layer contains the core business logic:
-
-- **Resize Service**: Handles image resizing operations
-- **Image Service**: Manages image processing and manipulation
-- **Storage Service**: Interfaces with storage backends
-- **Cache Service**: Provides caching functionality
-- **Health Service**: Monitors system health
-- **Metrics Service**: Collects and exposes metrics
-
-### Storage
-
-The storage component provides a unified interface for different storage backends:
-
-- S3 Storage
-- Local Filesystem Storage
-- In-Memory Storage
-
-### Cache
-
-The cache component improves performance by storing frequently accessed images.
-
-## Request Flow
-
-1. Client sends a request to resize an image
-2. API layer receives the request and validates parameters
-3. Router routes the request to the Resize Service
-4. Resize Service checks the Cache for the requested image
-5. If not in cache, Resize Service retrieves the image from the source URL
-6. Resize Service processes the image according to the requested parameters
-7. Processed image is stored in the Cache
-8. Processed image is returned to the client
-
-## Technology Stack
-
-- **Language**: Rust
-- **Web Framework**: Axum/Actix/Rocket (based on project structure)
-- **Image Processing**: image-rs
-- **Storage**: AWS SDK for S3, local filesystem
-- **Containerization**: Docker
-- **Orchestration**: Kubernetes via Helm
-- **Monitoring**: Prometheus metrics
+There is no generated OpenAPI server in this codebase today. The service used to be built around a
+`gen-server`/`packages/`/`openapi.yaml` generated router; that was removed as part of a hand-written-
+router rewrite (issue #53) and no longer exists anywhere in the tree or in `Cargo.toml`.

--- a/docs/configuration/performance.md
+++ b/docs/configuration/performance.md
@@ -1,21 +1,64 @@
 # Performance Configuration
 
-The image resize service now supports configuring performance parameters through environment variables, providing flexibility without requiring code changes.
+Every performance-relevant tunable is set through environment variables, no code changes required. This page is the knobs; for what the mechanisms behind them actually do, see [`PERFORMANCE_OPTIMIZATIONS.md`](../../PERFORMANCE_OPTIMIZATIONS.md); for measured numbers (criterion micro-benchmarks and the end-to-end comparison against imgproxy), see [`.bench-baseline/BASELINE.md`](../../.bench-baseline/BASELINE.md).
 
 ## Environment Variables
 
 ### Basic Performance Settings
 
+All read by `envconfig` in `src/modules/env/env.rs` and converted into a
+`PerformanceConfig` (`src/config/performance.rs`).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MAX_CONCURRENT_DOWNLOADS` | `20` | Maximum number of concurrent image downloads |
-| `MAX_CONCURRENT_PROCESSING` | CPU count | Maximum number of concurrent image processing tasks |
+| `MAX_CONCURRENT_DOWNLOADS` | `20` | Maximum number of concurrent image downloads (`download_semaphore`) |
+| `MAX_CONCURRENT_PROCESSING` | CPU count | Maximum number of concurrent decode/resize/encode tasks (`processing_semaphore`, #30) |
 | `HTTP_TIMEOUT_SECS` | `30` | HTTP client timeout in seconds |
-| `MAX_IMAGE_SIZE_MB` | `50` | Maximum image size in megabytes |
-| `CPU_THREAD_POOL_SIZE` | CPU count | Size of the CPU thread pool for image processing |
-| `ENABLE_HTTP2` | `true` | Enable HTTP/2 for downloads |
+| `MAX_IMAGE_SIZE_MB` | `50` | Maximum source image size in megabytes, enforced per downloaded chunk (#22) |
+| `CPU_THREAD_POOL_SIZE` | CPU count | Advisory only - see the note below |
+| `ENABLE_HTTP2` | `true` in code's own `Default`/preset values, but **`false`** in practice when unset - see the note below | Enable HTTP/2 for downloads |
 | `CONNECTION_POOL_SIZE` | `50` | Connection pool size per host |
 | `KEEP_ALIVE_TIMEOUT_SECS` | `60` | Keep-alive timeout for connections in seconds |
+
+> **`ENABLE_HTTP2` default discrepancy, verified against
+> `src/config/performance.rs`:** `PerformanceConfig::default()` and the
+> `high_throughput`/`low_latency` presets below all set `enable_http2:
+> true`. But the code path actually used at startup with no
+> `PERFORMANCE_PROFILE` set - the fallback arm of `impl From<&EnvConfig>
+> for PerformanceConfig` - reads `env_config.enable_http2.unwrap_or(false)`.
+> A deployment that sets neither `PERFORMANCE_PROFILE` nor `ENABLE_HTTP2`
+> therefore runs with HTTP/2 **disabled**, not enabled as every other
+> default in this file would suggest. Set `ENABLE_HTTP2=true` explicitly if
+> you want it and aren't using one of the profiles below (both of which set
+> it via their own struct literal, independent of this fallback).
+>
+> **`CPU_THREAD_POOL_SIZE` is read and stored (`PerformanceConfig::cpu_thread_pool_size`,
+> exposed via `get_cpu_thread_pool_size()`) but nothing in `src/` currently
+> calls `get_cpu_thread_pool_size()`** - CPU-bound work runs on Tokio's own
+> blocking-task pool via `spawn_blocking`, gated by `MAX_CONCURRENT_PROCESSING`'s
+> semaphore, not a separately-sized pool. Setting this variable is
+> harmless but currently has no effect; `MAX_CONCURRENT_PROCESSING` is the
+> variable that actually bounds CPU concurrency.
+
+### Router-level saturation and rate limiting
+
+A second, independent set of knobs bounds total request concurrency and
+per-IP request rate at the router (`src/modules/router/middlewares.rs`,
+#43) - separate from `MAX_CONCURRENT_PROCESSING` above, which only bounds
+the CPU-bound stage of an already-admitted request. These are read
+directly from the process environment (not via `envconfig`/`EnvConfig`),
+so `docs-env-drift` CI's `EnvConfig`-vs-`.env.example` check does not cover
+them - they are documented here instead.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_CONCURRENT_REQUESTS` | `512` | Total requests handled concurrently across all routes. Beyond this, a request is shed with `503` immediately rather than queued. |
+| `REQUEST_TIMEOUT_SECS` | `30` | Hard ceiling on end-to-end request time; a request still running past this is shed with `503`. |
+| `RATE_LIMIT_BURST` | `20` | Per-IP token-bucket burst size before rate limiting engages. |
+| `RATE_LIMIT_PERIOD_MS` | `100` | Per-IP token-bucket refill period (default: one additional request roughly every 100ms, i.e. ~10 req/s sustained per IP). |
+
+A `0` value for any of the four is treated as unset (falls back to the
+default above) rather than as a literal zero limit.
 
 ### Performance Profiles
 
@@ -101,15 +144,6 @@ export MAX_IMAGE_SIZE_MB=10
 - `CONNECTION_POOL_SIZE`: 10
 - `KEEP_ALIVE_TIMEOUT_SECS`: 30
 
-## Migration from Hardcoded Configuration
-
-Previously, performance settings were hardcoded in the application. With this update:
-
-1. **Default behavior remains the same** - if no environment variables are set, the service uses the same defaults as before
-2. **Gradual migration** - you can override individual settings without changing everything at once
-3. **Profile-based configuration** - use predefined profiles for common use cases
-4. **Fine-tuning** - combine profiles with individual overrides for optimal performance
-
 ## Monitoring and Tuning
 
 Monitor your application's performance metrics to determine optimal settings:
@@ -127,16 +161,36 @@ The included benchmark tool is now fully configurable through environment variab
 
 ### Benchmark Environment Variables
 
+Source of truth: `src/bin/benchmark.rs`'s `BenchmarkConfig`.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BENCHMARK_HOST` | `localhost` | Target host for benchmark requests |
-| `BENCHMARK_PORT` | `3000` | Target port for benchmark requests |
+| `BENCHMARK_HOST` | `localhost` | Target host of the service under test |
+| `BENCHMARK_PORT` | `3000` | Target port of the service under test |
 | `BENCHMARK_CONCURRENCY_LEVELS` | `1,5,10,20,50` | Comma-separated list of concurrency levels to test |
-| `BENCHMARK_TEST_URLS` | `https://picsum.photos/...` | Comma-separated list of test image URLs |
+| `BENCHMARK_REQUESTS_PER_LEVEL` | `200` | Timed requests run at each concurrency level - the sample size percentiles (especially p99.9) are computed from |
+| `BENCHMARK_WARMUP_REQUESTS` | `10` | Requests run and discarded before each level is timed, so every level is measured warm |
+| `BENCHMARK_FIXTURE_NAMES` | `photo_like,flat,alpha,tiny` | Comma-separated list of generated fixtures (see `benches/fixtures.rs`) to rotate through as source images |
 | `BENCHMARK_RESIZE_PARAMS` | `300x300,800x,x600,1200x800` | Comma-separated list of resize parameters (format: `WIDTHxHEIGHT`) |
 | `BENCHMARK_WAIT_BETWEEN_TESTS` | `2` | Seconds to wait between different concurrency level tests |
-| `BENCHMARK_REQUEST_TIMEOUT` | `30` | Request timeout in seconds |
-| `BENCHMARK_OUTPUT_FORMAT` | `jpg` | Output image format for resize requests |
+| `BENCHMARK_REQUEST_TIMEOUT` | `60` | Per-request timeout in seconds |
+| `BENCHMARK_OUTPUT_FORMAT` | `jpg` | Output image format for resize requests (`jpg`\|`png`\|`webp`\|`avif`\|`gif`) |
+| `BENCHMARK_FIXTURE_HOST` | `127.0.0.1` | Bind address of the local fixture-serving HTTP origin the benchmark starts inside its own process |
+| `BENCHMARK_FIXTURE_PORT` | `0` (random free port) | Port for the local fixture origin above |
+| `BENCHMARK_JSON_OUTPUT` | `target/benchmark-results.json` | Path to write the machine-readable JSON report to, alongside the human-readable table |
+
+The benchmark no longer fetches source images over the network. It used to
+pull real photos from `picsum.photos` via a `BENCHMARK_TEST_URLS` variable;
+that variable is gone. Test images are now served from a tiny local axum
+server this binary starts inside its own process, using the same
+deterministic, generated fixture corpus the criterion benches use
+(`benches/fixtures.rs`) - so the "origin" the target service downloads from
+adds no internet variance to the results, and a benchmark run needs no
+network access at all. Redirects are still followed end-to-end (the target
+service's `301` to its own storage-backed URL, `reqwest`'s default policy),
+so a benchmark run against a real deployment still measures the full
+download → process → upload → redirect → re-fetch path, not just the
+redirect hop.
 
 ### Resize Parameters Format
 
@@ -170,10 +224,11 @@ export BENCHMARK_REQUEST_TIMEOUT=60
 cargo run --bin benchmark
 ```
 
-#### Custom Test Images
+#### Custom Fixtures And Output Format
 ```bash
-# Use your own test images
-export BENCHMARK_TEST_URLS="https://example.com/image1.jpg,https://example.com/image2.png,https://example.com/image3.webp"
+# Choose which generated fixtures to rotate through (see benches/fixtures.rs
+# for the full set) and a different output format
+export BENCHMARK_FIXTURE_NAMES="photo_like,alpha"
 export BENCHMARK_RESIZE_PARAMS="100x100,500x500,1000x,x800"
 export BENCHMARK_OUTPUT_FORMAT=webp
 cargo run --bin benchmark
@@ -190,12 +245,12 @@ cargo run --bin benchmark
 
 ### Benchmark Output
 
-The benchmark provides detailed performance metrics:
-- **Successful requests** - Number of successful vs total requests
-- **Total time** - Time taken for all requests at each concurrency level
-- **Requests/sec** - Throughput measurement
-- **Throughput** - Data transfer rate in MB/s
-- **Response times** - Average, minimum, and maximum response times
+For each concurrency level, the benchmark prints:
+- **Request outcomes** - counts broken down by success, non-2xx, timeout, and connection error, not a single pass/fail count
+- **Duration and throughput** - total wall-clock time for the level and the resulting requests/sec
+- **Latency percentiles (successes only)** - mean, min, max, p50, p90, p99, and p99.9, in milliseconds
+
+It also writes a machine-readable JSON report (`BENCHMARK_JSON_OUTPUT`, default `target/benchmark-results.json`) with the same data, so CI can diff runs over time.
 
 ### Integration with Performance Profiles
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,98 +1,190 @@
 # Docker Deployment
 
-This guide explains how to deploy the Image Resize Service using Docker.
+This guide explains how to build and run `emgr` with Docker.
 
 ## Prerequisites
 
-- Docker installed
+- Docker, with Buildx (for `docker build`).
+- Docker Compose v2 (`docker compose`, not the standalone `docker-compose`)
+  if you use `compose.yaml`.
 
-## Building the Docker Image
+## Building the Docker image
 
-A `Dockerfile` is provided in the project root.
+The `Dockerfile` in the project root defines **four deploy targets** and no
+default/unnamed final stage, so `--target` is required:
 
-The `Dockerfile` defines four deploy targets (no default/unnamed final
-stage), so `--target` is required: `fs_deploy` (local filesystem
-storage), `fs_otel_deploy` (+ OpenTelemetry), `s3_deploy` (MinIO/S3
-storage), `s3_otel_deploy` (+ OpenTelemetry). `healthcheck.rs` is built
-into all four automatically.
+| Target | Storage | OpenTelemetry / `/metrics` |
+|---|---|---|
+| `fs_deploy` | local filesystem | no |
+| `fs_otel_deploy` | local filesystem | yes |
+| `s3_deploy` | S3 / MinIO | no |
+| `s3_otel_deploy` | S3 / MinIO | yes |
+
+`healthcheck` (the binary the image's own `HEALTHCHECK` runs) is built into
+all four automatically.
 
 ```bash
-# Navigate to the project root
 cd /path/to/image-resizer
 
-# Build the Docker image (local filesystem storage, no OTel)
-docker build --target fs_deploy -t image-resizer:latest .
+# Build the image (local filesystem storage, no OTel)
+docker build --target fs_deploy -t emgr:latest .
 ```
 
-## Running the Docker Container
+### The builder/runtime base image pin - do not bump casually
 
-### Basic run
+The builder stage is pinned by digest to a **Debian 12 ("bookworm")** Rust
+image, and the runtime stage to `gcr.io/distroless/cc-debian12` - on
+purpose, and they must move together. A previous version of this Dockerfile
+used a Debian 13 ("trixie") builder (glibc 2.41) against this same
+bookworm-based runtime (glibc 2.36); the `s3` build's native C dependency
+(`aws-lc-sys`) referenced `GLIBC_2.38` symbols, and the resulting image
+built cleanly, pushed successfully, and then died instantly on start with:
+
+```text
+version 'GLIBC_2.38' not found
+```
+
+CI never caught it, because the build pipeline built and pushed images
+without ever running one - see the "run every built image before pushing
+it" fix (`.github/workflows/build.yml`) that closed that gap. `local_fs`
+survived only by luck (it happens not to touch the symbols in question).
+
+If you ever need to bump either base image, bump both in lockstep and
+actually run the resulting image before merging - don't rely on CI's
+static checks to catch a glibc mismatch, they won't.
+
+## Running the container
+
+`emgr` fails closed at startup - see
+[Installation](../getting-started/installation.md#configure-the-two-startup-checks)
+for the full explanation. In short, every run needs:
+
+- `SIGNING_KEY` + `SIGNING_SALT` (hex-encoded), or `ALLOW_UNSIGNED_REQUESTS=true`.
+- On an `*_otel_deploy` image only: `METRICS_AUTH_TOKEN`, or
+  `ALLOW_UNAUTHENTICATED_METRICS=true`.
+
+A container started without satisfying these exits immediately with a
+clear error - it does not hang or serve broken responses.
+
+### Basic run (local filesystem, signing disabled for local testing)
 
 The service listens on port `3000` by default (`PORT`, `HOST`):
 
 ```bash
-docker run -d -p 3000:3000 --name image-resizer-app image-resizer:latest
+docker run -d -p 3000:3000 \
+  -e ALLOW_UNSIGNED_REQUESTS=true \
+  -e LOCAL_FS_STORAGE_PATH=/app/data/images \
+  --name emgr-app \
+  emgr:latest
 ```
 
-### With environment variables
+### With S3/MinIO storage and real signing
 
-You can configure the service using environment variables. See the [Configuration](../getting-started/configuration.md) guide for the full list.
+You can configure the service using environment variables - see
+[Configuration](../getting-started/configuration.md) for the full list.
 
 ```bash
 docker run -d -p 3000:3000 \
+  -e SIGNING_KEY=$(openssl rand -hex 32) \
+  -e SIGNING_SALT=$(openssl rand -hex 16) \
   -e STORAGE_TYPE=S3 \
   -e MINIO_ENDPOINT_URL=https://s3.amazonaws.com \
   -e MINIO_BUCKET=my-image-bucket \
   -e MINIO_ACCESS_KEY_ID=YOUR_ACCESS_KEY \
   -e MINIO_SECRET_ACCESS_KEY=YOUR_SECRET_KEY \
   -e MINIO_REGION=us-east-1 \
-  --name image-resizer-app \
+  --name emgr-app \
   ghcr.io/vaam-store/image-resizer:s3-latest
 ```
 
-(`ghcr.io/vaam-store/image-resizer:s3-latest`, built from the `s3_deploy`
-target, is what `.github/workflows/build.yml` publishes - only build
-locally with `docker build --target s3_deploy` if you need an
-unpublished change.)
+`ghcr.io/vaam-store/image-resizer:s3-latest` (built from the `s3_deploy`
+target) is what `.github/workflows/build.yml` publishes on every push to
+`main`, alongside `fs-latest`, `fs_otel-latest` and `s3_otel-latest` (each
+also gets a per-commit `<flavor>-<sha>` tag). There is no floating,
+un-prefixed `latest` tag - build.yml has no release-tag trigger today, so
+none of these are semver-stable either; pin a specific `<flavor>-<sha>`
+for anything beyond local testing. Only build locally with
+`docker build --target s3_deploy` if you need an unpublished change.
 
 ### Using Docker Compose
 
-A `compose.yaml` file is provided for easier local development and deployment.
+`compose.yaml` in the project root brings up the `app` service (local
+filesystem, `fs_otel_deploy` target) and `app-s3` (`s3_otel_deploy`
+target, backed by a local MinIO), plus a Jaeger all-in-one container for
+the OTel traces both services emit - both are `*_otel_deploy` builds, so
+both need `/metrics` auth configured, not just signing.
 
-```bash
-# Start the service
-docker-compose up -d
+**As committed, neither service will start.** `compose.yaml`'s
+`environment:` blocks for `app` and `app-s3` don't reference
+`SIGNING_KEY`/`SIGNING_SALT`/`ALLOW_UNSIGNED_REQUESTS` or
+`METRICS_AUTH_TOKEN`/`ALLOW_UNAUTHENTICATED_METRICS` at all - `.env`
+(`cp .env.example .env`) does not fix this on its own, since Compose only
+uses a root `.env` file for `${VAR}` substitution *inside* `compose.yaml`,
+and nothing in `compose.yaml` reads those five variables into either
+service. Confirm this yourself with `docker compose config` - the
+resolved `environment:` for `app`/`app-s3` has no signing- or
+metrics-auth-related keys, with or without a populated `.env`.
 
-# Stop the service
-docker-compose down
+Until `compose.yaml` is updated to forward them, add an override file
+(auto-loaded by `docker compose` alongside `compose.yaml`, no `-f` flag
+needed):
 
-# View logs
-docker-compose logs -f
+```yaml
+# compose.override.yaml (local only - not tracked in git)
+services:
+  app:
+    environment:
+      SIGNING_KEY: ${SIGNING_KEY}
+      SIGNING_SALT: ${SIGNING_SALT}
+      METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN}
+  app-s3:
+    environment:
+      SIGNING_KEY: ${SIGNING_KEY}
+      SIGNING_SALT: ${SIGNING_SALT}
+      METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN}
 ```
 
-The `compose.yaml` file typically includes:
-- The application service definition.
-- Potentially other services like a local MinIO instance for S3 testing.
+```bash
+cp .env.example .env   # also uncomment/set SIGNING_KEY, SIGNING_SALT, METRICS_AUTH_TOKEN in it
 
-Refer to the `compose.yaml` in the project root for the exact configuration.
+# Start everything
+docker compose up -d --build
 
-## Managing the Container
+# Stop
+docker compose down
 
-- **View logs**: `docker logs image-resizer-app`
-- **Stop the container**: `docker stop image-resizer-app`
-- **Start the container**: `docker start image-resizer-app`
-- **Remove the container**: `docker rm image-resizer-app`
+# View logs
+docker compose logs -f
+```
 
-## Pushing to a Docker Registry
+The `Makefile` wraps the same compose invocations (`make up`, `make down`,
+`make logs`, `make ps` - see `make help` for the full list) with the
+project name pinned to `emgr`; the override file above applies to those
+too, since `make` doesn't pass `-f`.
 
-If you want to deploy the image to a remote environment (like Kubernetes), you'll need to push it to a Docker registry (e.g., Docker Hub, AWS ECR, Google GCR).
+## Managing the container
+
+- **View logs**: `docker logs emgr-app`
+- **Stop the container**: `docker stop emgr-app`
+- **Start the container**: `docker start emgr-app`
+- **Remove the container**: `docker rm emgr-app`
+
+## Pushing to a Docker registry
+
+If you want to deploy a locally built image to a remote environment (like
+Kubernetes), push it to a registry (Docker Hub, AWS ECR, Google GCR, ...):
 
 ```bash
 # Tag the image (replace <your-registry-username> and <repository-name>)
-docker tag image-resizer:latest <your-registry-username>/<repository-name>:latest
+docker tag emgr:latest <your-registry-username>/<repository-name>:latest
 
 # Log in to your Docker registry
 docker login
 
 # Push the image
 docker push <your-registry-username>/<repository-name>:latest
+```
+
+In this repository, `.github/workflows/build.yml` does this automatically
+on every push, publishing all four flavours to
+`ghcr.io/vaam-store/image-resizer` - see the tag naming note above.

--- a/docs/deployment/helm-chart.md
+++ b/docs/deployment/helm-chart.md
@@ -1,82 +1,259 @@
 # Helm Chart Deployment
 
-This guide explains how to deploy the Image Resize Service to Kubernetes using the provided Helm chart.
+This repository ships **two** Helm charts, for two different deployment
+models:
+
+| Chart | Path | Workload kind | Use when |
+|---|---|---|---|
+| `emgr` | `helm/emgr/` | Standard Kubernetes `Deployment` (via the [bjw-s common library chart](https://bjw-s-labs.github.io/helm-charts/)) | You want a normal, always-on Deployment - fixed `replicaCount`, an optional HPA, a `PersistentVolumeClaim` for `local_fs` storage. |
+| `emgr-serverless` | `helm/serverless/` | [Knative](https://knative.dev/) `Service` (via the Bitnami common library chart) | You run Knative and want scale-to-zero, and S3/MinIO storage (no local disk needed). |
+
+Both charts install `emgr` itself; pick one, not both, for a given
+deployment.
 
 ## Prerequisites
 
-- Kubernetes cluster
-- Helm 3 installed
+- A Kubernetes cluster and Helm 3.
+- For `emgr-serverless`: [Knative Serving](https://knative.dev/docs/install/) installed on the cluster, and `cert-manager` if you enable `domain.tls.issuerRef`.
 
-## Chart Location
+## `emgr` (Deployment chart)
 
-The Helm chart is located in the `helm/emgr/` directory in the repository.
+### Chart location
 
-## Configuration
+`helm/emgr/`. `Chart.yaml` pins its `common` dependency to `bjw-s`'s
+library chart `4.0.1` (see `helm/emgr/Chart.lock`) - most of the templating
+(Deployment, Service, Ingress, ConfigMap, HPA, PVC) comes from that
+library via `templates/common.yaml`'s single
+`{{ include "bjw-s.common.loader.all" $ }}`. Two plain templates are
+layered on top:
 
-You can customize the deployment by modifying the `helm/emgr/values.yaml` file.
+- `templates/poddisruptionbudget.yaml` - a `PodDisruptionBudget` with
+  `minAvailable: 1`, added because the pinned `4.0.1` library predates
+  that chart's own `podDisruptionBudget` values key. Without it, a
+  voluntary disruption (node drain, cluster upgrade) could evict every
+  `main` replica at once.
+- The probes under `controllers.main.containers.app.probes` in
+  `values.yaml` - the bjw-s common library does **not** synthesize
+  liveness/readiness/startup probe defaults, so without this block
+  traffic would route to pods before storage finishes initializing, and a
+  wedged container would never be restarted.
 
-Key configuration options:
+### Probes
 
-- `replicaCount`: Number of replicas
-- `image.repository`: Docker image repository
-- `image.pullPolicy`: Image pull policy
-- `image.tag`: Image tag
-- `service.type`: Service type (ClusterIP, NodePort, LoadBalancer)
-- `service.port`: Service port
-- `ingress.enabled`: Enable Ingress
-- `ingress.className`: Ingress class name
-- `ingress.hosts`: Ingress hosts
-- `ingress.tls`: Ingress TLS configuration
-- `resources`: CPU/memory resource requests and limits
-- `autoscaling.enabled`: Enable Horizontal Pod Autoscaler
-- `autoscaling.minReplicas`: Minimum replicas for HPA
-- `autoscaling.maxReplicas`: Maximum replicas for HPA
-- `autoscaling.targetCPUUtilizationPercentage`: Target CPU utilization
-- `autoscaling.targetMemoryUtilizationPercentage`: Target memory utilization
-- `envVars`: Environment variables for the application (see [Configuration](../getting-started/configuration.md))
+All three probes are plain Kubernetes HTTP probes against `/health` on
+port `3000` (`values.yaml`, `controllers.main.containers.app.probes`):
 
-## Deployment Steps
+| Probe | initialDelay | period | timeout | failureThreshold |
+|---|---|---|---|---|
+| liveness | 5s | 10s | 2s | 3 |
+| readiness | 5s | 10s | 2s | 3 |
+| startup | 0s | 5s | - | 30 (150s total before the container is killed for never finishing startup) |
 
-### 1. Add Helm Repository (if applicable)
+### What the chart configures out of the box
 
-If the chart is hosted in a Helm repository, add it first:
+`values.yaml`'s `configMaps.config.data` sets exactly three variables:
 
-```bash
-helm repo add <repo-name> <repo-url>
-helm repo update
+```yaml
+LOCAL_FS_STORAGE_PATH: /tmp/data/images
+CDN_BASE_URL: https://emgr.com
+PERFORMANCE_PROFILE: high_throughput
 ```
 
-### 2. Install the Chart
+...loaded via `envFrom: configMapRef` on the `app` container. A
+`permission-fix` init container (running as root) `chown`s/`chmod`s the
+mounted `ReadWriteMany` PVC to uid/gid `1001` before the app container
+(which runs as that non-root user, `defaultPodOptions.securityContext`)
+starts.
 
-Navigate to the chart directory or use the repository:
+### What the chart does *not* configure - you must add it
 
-```bash
-# From local directory
-helm install image-resizer ./helm/emgr --namespace image-resizer --create-namespace
+**The chart as shipped does not set `SIGNING_KEY`/`SIGNING_SALT` (or
+`ALLOW_UNSIGNED_REQUESTS`), and does not set `METRICS_AUTH_TOKEN` (or
+`ALLOW_UNAUTHENTICATED_METRICS`).** `emgr` fails closed at startup without
+these (see [Installation](../getting-started/installation.md#configure-the-two-startup-checks)),
+so a pod deployed from this chart's defaults will crash-loop. Add them
+yourself in a values override - the bjw-s common library supports either
+plain values or a `Secret`-backed reference on the same container:
 
-# Or from Helm repository
-helm install image-resizer <repo-name>/emgr --namespace image-resizer --create-namespace
+```yaml
+# values-signing.yaml
+controllers:
+  main:
+    containers:
+      app:
+        env:
+          SIGNING_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: emgr-signing
+                key: signing-key
+          SIGNING_SALT:
+            valueFrom:
+              secretKeyRef:
+                name: emgr-signing
+                key: signing-salt
+          METRICS_AUTH_TOKEN:
+            valueFrom:
+              secretKeyRef:
+                name: emgr-signing
+                key: metrics-auth-token
 ```
 
-### 3. Verify the Deployment
+(with `emgr-signing` a `Secret` you create separately - the chart does not
+create one for you) - or the equivalent inline `env` map if you don't want
+a `Secret`. See the
+[bjw-s common library's `env`/`envFrom` docs](https://bjw-s-labs.github.io/helm-charts/docs/common-library/values/#env-and-envfrom)
+for the full schema. The image itself must also be an `otel`-enabled
+build for `METRICS_AUTH_TOKEN` to matter at all - see the image tag note
+below.
+
+### Image tag
+
+`values.yaml`'s `global.version` defaults to `fs-latest` - a **floating**
+tag (moves on every push to `main`; `.github/workflows/build.yml` has no
+release-tag trigger, so there's no immutable semver tag to default to
+instead). `fs-latest` is a `local_fs`-only, non-`otel` build, so
+`METRICS_AUTH_TOKEN` doesn't apply unless you override `global.version` to
+one of the `*_otel-*` flavours (see [Docker deployment](docker.md) for the
+full tag list). Pin `global.version` to a specific `fs-<sha>` (or
+`fs_otel-<sha>`) tag for anything beyond a quick smoke test -
+`pullPolicy: Always` on the container is a direct consequence of the
+default floating tag, so different pods don't silently end up running
+different builds under the same tag name.
+
+### Deployment steps
 
 ```bash
-kubectl get pods -n image-resizer
-kubectl get svc -n image-resizer
+# From the local chart directory (no chart repository is published today)
+helm dependency build ./helm/emgr
+helm install emgr ./helm/emgr \
+  --namespace emgr --create-namespace \
+  -f values-signing.yaml   # your own override, see above
+
+kubectl get pods -n emgr
+kubectl get svc -n emgr
 ```
 
-## Upgrading the Deployment
+Upgrade / uninstall:
 
 ```bash
-helm upgrade image-resizer ./helm/emgr --namespace image-resizer
+helm upgrade emgr ./helm/emgr --namespace emgr -f values-signing.yaml
+helm uninstall emgr --namespace emgr
 ```
 
-## Uninstalling the Deployment
+## `emgr-serverless` (Knative chart)
+
+### Chart location
+
+`helm/serverless/`, depending on Bitnami's `common` library chart
+(`Chart.yaml`; pulled from `oci://registry-1.docker.io/bitnamicharts`).
+`templates/knative-service.yaml` renders a single
+`serving.knative.dev/v1` `Service`; `templates/kserving-domain-mapping.yaml`
+optionally adds a Knative `DomainMapping` (and a cert-manager
+`Certificate`, if `domain.tls.issuerRef` is set) when `domain.enabled: true`.
+
+### Probes
+
+Unlike the Deployment chart, these are **Knative-native** probes (still
+plain `httpGet` on `/health`, port `3000` from `ports.http1.port`) -
+`readinessProbe`, `livenessProbe` and `startupProbe`, each with no
+explicit timing overrides, so Knative's own probe defaults apply.
+
+### What the chart configures out of the box
+
+`values.yaml`'s `env` map is wired for **S3/MinIO storage**, with the
+MinIO credentials already sourced from a `Secret` (name `minio`, keys
+`access-key`/`secret-key`) via `secretKeyRef` - the same pattern you'd use
+to add signing/metrics-auth secrets, see below:
+
+```yaml
+env:
+  MINIO_ACCESS_KEY_ID: { secretKeyRef: { name: minio, key: access-key } }
+  MINIO_SECRET_ACCESS_KEY: { secretKeyRef: { name: minio, key: secret-key } }
+  MINIO_ENDPOINT_URL: http://minio:9000
+  MINIO_BUCKET: emgr
+  # ...
+```
+
+### What the chart does *not* configure - you must add it
+
+Exactly like the `emgr` chart above, **no `SIGNING_KEY`/`SIGNING_SALT`
+(or `ALLOW_UNSIGNED_REQUESTS`) and no `METRICS_AUTH_TOKEN` (or
+`ALLOW_UNAUTHENTICATED_METRICS`) are set**, so a Knative revision deployed
+from these defaults will fail its startup probe and never go Ready. Add
+them to `values.yaml`'s `env` map using the same `secretKeyRef` shape
+already used for `MINIO_ACCESS_KEY_ID` above, e.g.:
+
+```yaml
+env:
+  SIGNING_KEY: { secretKeyRef: { name: emgr-signing, key: signing-key } }
+  SIGNING_SALT: { secretKeyRef: { name: emgr-signing, key: signing-salt } }
+  METRICS_AUTH_TOKEN: { secretKeyRef: { name: emgr-signing, key: metrics-auth-token } }
+```
+
+### Image tag - two confirmed problems, not just a stale default
+
+`values.yaml`'s `image.tag` defaults to a plain `"latest"` - **this does
+not correspond to any image `.github/workflows/build.yml` actually
+publishes.** Every published tag is flavour-prefixed (`fs-latest`,
+`fs_otel-latest`, `s3-latest`, `s3_otel-latest`, plus per-commit
+`<flavor>-<sha>` - see [Docker deployment](docker.md)); there is no
+bare `latest`. Given this chart's `env` defaults assume S3/MinIO storage
+and it sends `LOG_LEVEL`/`OTLP_*` variables (meaningful only on an `otel`
+build), you'd want `s3_otel-latest` or a pinned `s3_otel-<sha>` instead.
+
+Overriding `image.tag` alone still won't produce a working image
+reference, though - `helm template ./helm/serverless` (verified directly)
+renders:
+
+```yaml
+- image: ghcr.io/ghcr.io/vaam-store/image-resizer:latest
+```
+
+`values.yaml` sets both `image.registry: ghcr.io` **and**
+`image.repository: ghcr.io/vaam-store/image-resizer` (the repository
+already includes the registry host), and the Bitnami `common.images.image`
+helper this chart uses concatenates `registry`/`repository` unconditionally
+- producing a doubled, non-existent `ghcr.io/ghcr.io/...` reference. Until
+this is fixed in the chart, override `image.registry: ""` (empty) in your
+values, alongside `image.tag`, or set `image.repository` to just
+`vaam-store/image-resizer`.
+
+Separately (also verified via `helm template`), `values.yaml`'s
+`env.LOG_LEVEL: ${LOG_LEVEL:-info}` is Docker Compose's `${VAR:-default}`
+substitution syntax, which Helm does not evaluate - it renders as the
+**literal string** `${LOG_LEVEL:-info}` for the container's `LOG_LEVEL`
+env var, not a resolved default. Override `env.LOG_LEVEL` to an actual
+level (e.g. `info`) in your values file.
+
+### Deployment steps
 
 ```bash
-helm uninstall image-resizer --namespace image-resizer
+helm dependency build ./helm/serverless
+helm install emgr-serverless ./helm/serverless \
+  --namespace emgr --create-namespace \
+  --set image.registry="" \
+  --set image.tag=s3_otel-latest \
+  --set env.LOG_LEVEL=info \
+  -f values-signing.yaml
+
+kubectl get ksvc -n emgr
 ```
 
-## GitHub Pages Deployment
+Upgrade / uninstall:
 
-The documentation itself can be deployed to GitHub Pages. This is typically handled by a GitHub Actions workflow. See [GitHub Actions Workflow](#github-actions-workflow) for more details.
+```bash
+helm upgrade emgr-serverless ./helm/serverless --namespace emgr -f values-signing.yaml
+helm uninstall emgr-serverless --namespace emgr
+```
+
+## Notes
+
+- Neither chart is published to a Helm repository today - both are
+  installed from the local `helm/emgr`/`helm/serverless` directories in
+  this checkout (`helm dependency build` first, to fetch the pinned
+  `common` library chart into `charts/`).
+- Configuration beyond what's listed above (performance tuning, the SSRF
+  guard, resolution limits, presets) works the same way: add the env var
+  from [Configuration](../getting-started/configuration.md) to whichever
+  chart's env mechanism you're using.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,64 +1,94 @@
 # Contributing
 
-Thank you for considering contributing to the Image Resize Service!
+Thank you for considering contributing to `emgr`!
 
-## How to Contribute
+## How to contribute
 
-We welcome contributions in various forms:
+- **Bug reports**: open an issue on GitHub.
+- **Feature requests**: open an issue to discuss it first.
+- **Code contributions**: pull requests are welcome.
+- **Documentation improvements**: if you find a gap or an error, open an
+  issue or a pull request.
 
-- **Bug Reports**: If you find a bug, please open an issue on GitHub.
-- **Feature Requests**: If you have an idea for a new feature, please open an issue to discuss it.
-- **Code Contributions**: Pull requests are welcome!
-- **Documentation Improvements**: If you find any gaps or errors in the documentation, please let us know or submit a pull request.
+## Development setup
 
-## Development Setup
+See [Installation](../getting-started/installation.md) for cloning the
+repository, picking a Cargo feature set (there is no default storage
+backend - `local_fs`/`s3`/`in_memory`, plus `otel` optionally), and the two
+environment variables the service requires before it will start
+(`SIGNING_KEY`/`SIGNING_SALT` or `ALLOW_UNSIGNED_REQUESTS`, and, on `otel`
+builds, `METRICS_AUTH_TOKEN` or `ALLOW_UNAUTHENTICATED_METRICS`).
 
-Please refer to the [Installation](../getting-started/installation.md) guide for setting up your local development environment.
+## Code style
 
-## Code Style
+This project follows standard Rust formatting - run `cargo fmt` before
+submitting a pull request. There's no repo-specific `rustfmt.toml`, so
+`rustfmt`'s defaults apply.
 
-This project follows standard Rust coding conventions. Please run `cargo fmt` to format your code before submitting a pull request.
-
-We also use Clippy for linting:
+Clippy is checked in CI (`.github/workflows/ci.yml`'s `clippy` job), run
+against a single representative feature set:
 
 ```bash
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --features local_fs --all-targets -- -D warnings
 ```
 
-Refer to the `.clippy.toml` file for specific Clippy configurations.
+That job is currently `continue-on-error: true` (non-blocking) while an
+existing warning backlog (`dead_code`, `collapsible_if`,
+`manual_saturating_arithmetic`, doc-list-item indentation, and a few
+others - run it locally to see the current set) gets cleared - see the
+job's own comment in `ci.yml` for the tracked issue. Still run it locally
+and avoid adding to the backlog; `.clippy.toml` sets stricter-than-default
+`too-many-arguments-threshold` and `cognitive-complexity-threshold`
+because this service decodes attacker-supplied image bytes, and an
+accidental panic in a request path is a denial-of-service primitive - keep
+the bar low enough for new `unwrap()`s to stand out in review.
 
-## Commit Messages
+`cargo-deny` (advisories, licenses, bans, sources - see `deny.toml`) also
+runs in CI and *is* blocking:
 
-Please follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for your commit messages. This helps in automating changelog generation and versioning.
+```bash
+cargo deny check
+```
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/)
+(`feat:`, `fix:`, `perf:`, `docs:`, `chore:`, ...) - this is what the
+project's own history already uses, and it keeps `git log --oneline`
+skimmable for changelog reconstruction.
 
 Example:
 
 ```
-feat: Add support for WEBP output format
+feat: add support for WEBP output format
 
 This commit introduces the ability to output images in WEBP format.
 - Added WEBP encoding option.
 - Updated API documentation.
 ```
 
-## Pull Request Process
+## Pull request process
 
-1.  **Fork the repository** and create your branch from `main`.
-2.  **Make your changes**.
-3.  **Add tests** for your changes.
-4.  **Ensure all tests pass**: `cargo test`.
-5.  **Format your code**: `cargo fmt`.
-6.  **Lint your code**: `cargo clippy`.
-7.  **Commit your changes** using conventional commit messages.
-8.  **Push your branch** to your fork.
-9.  **Open a pull request** to the `main` branch of the original repository.
-
-Please provide a clear description of your changes in the pull request.
-
-## Testing
-
-Refer to the [Testing](./testing.md) guide for more details on how to run and write tests.
+1. **Fork the repository** and create your branch from `main`.
+2. **Make your changes.**
+3. **Add tests** for your changes - see [Testing](testing.md) for the
+   project's actual test patterns (real backends over mocks, tests
+   co-located in `#[cfg(test)]` modules or in `tests/`).
+4. **If you add a new environment variable**, document it in
+   [Configuration](../getting-started/configuration.md) - CI's
+   `docs-env-drift` job (`.github/scripts/check_env_docs.py`) fails the
+   build if `src/modules/env/env.rs` and that page drift apart in either
+   direction.
+5. **Run the relevant test matrix locally** - at minimum the feature set
+   you touched; CI runs all three of `local_fs`, `s3`, and `local_fs,otel`
+   separately (see [Testing](testing.md)).
+6. **Format and lint**: `cargo fmt`, `cargo clippy --features local_fs --all-targets -- -D warnings`, `cargo deny check`.
+7. **Commit** using Conventional Commits.
+8. **Push your branch** to your fork.
+9. **Open a pull request** against `main`, with a clear description of
+   what changed and why.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [LICENSE](../about/license.md) file.
+By contributing, you agree that your contributions will be licensed under
+the project's [MIT license](../about/license.md).

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -6,31 +6,37 @@ convention and `mockall` usage that were never implemented).
 
 ## Running tests
 
-Most tests are gated behind the `local_fs` feature (the storage backend
-that doesn't need MinIO/S3 running), which is also what CI runs
-(`.github/workflows/ci.yml`'s `test` job):
+CI (`.github/workflows/ci.yml`'s `test` job) runs one job per feature set,
+each in isolation via `--no-default-features` (a no-op today since
+`default = []`, but it stops a future non-empty default from silently
+pulling `local_fs` into the `s3` job):
 
 ```bash
-cargo test --features local_fs
+cargo test --no-default-features --features local_fs
+cargo test --no-default-features --features s3
+cargo test --no-default-features --features local_fs,otel
 ```
 
-Some tests are storage-backend-agnostic and run with any feature set;
-`--features local_fs` is the fastest way to get a fully green run without
-standing up MinIO. To also exercise the S3-backed storage code paths you
-need a running MinIO (or S3-compatible) endpoint - see
-[Docker deployment](../deployment/docker.md) for `compose.yaml`'s
-`minio`/`minio-init` services - then run with `--features s3` instead.
+`local_fs` is the fastest way to get a fully green run without standing up
+anything external, and is what most tests are gated behind - some tests
+are storage-backend-agnostic and run under any feature set. To exercise
+the S3-backed storage code paths you need a running MinIO (or
+S3-compatible) endpoint - see [Docker deployment](../deployment/docker.md)
+for `compose.yaml`'s `minio`/`minio-init` services - then run with
+`--features s3`. `local_fs,otel` is the only combination that exercises
+the `/metrics` authentication middleware (`src/modules/metrics_auth`),
+since `/metrics` is only ever mounted on an `otel` build.
 
 ### Running specific tests
 
 ```bash
 # A single test function, across every target
-cargo test --features local_fs resize_success_returns_redirect
+cargo test --no-default-features --features local_fs resize_success_returns_redirect
 
 # Only the integration tests in tests/
-cargo test --features local_fs --test storage_key_validation
-cargo test --features local_fs --test storage_local_fs_atomicity
-cargo test --features local_fs --test fixtures_smoke
+cargo test --no-default-features --features local_fs --test storage_key_validation
+cargo test --no-default-features --features local_fs --test storage_local_fs_atomicity
+cargo test --no-default-features --features local_fs --test fixtures_smoke
 ```
 
 ## Test organization
@@ -67,13 +73,52 @@ library for a service whose bugs tend to live exactly in the interaction
 with real filesystems and real HTTP responses (partial writes, redirects,
 percent-encoding).
 
+## Environment variable documentation is CI-checked
+
+Every `#[envconfig(from = "...")]` field in `src/modules/env/env.rs` must
+have a matching entry in [Configuration](../getting-started/configuration.md)
+- CI's `docs-env-drift` job runs `.github/scripts/check_env_docs.py`, which
+fails the build if the two drift apart in either direction (GH #47). Run
+it locally before opening a PR that adds or renames an environment
+variable:
+
+```bash
+python3 .github/scripts/check_env_docs.py
+```
+
 ## Benchmarks
 
-Not part of `cargo test` - criterion benches live in `benches/` and are
-run with `cargo bench --features local_fs` (wired into CI's regression
-gate, see [GH #20](https://github.com/vaam-store/image-resizer/issues/20)).
-`src/bin/benchmark.rs` is a separate end-to-end HTTP load-test binary
-against a running server, not a criterion bench - see its own `--help`.
+Two separate layers, neither part of `cargo test`:
+
+### Criterion micro-benchmarks (`benches/`)
+
+```bash
+cargo bench --features local_fs
+```
+
+Wired into CI's regression gate (see
+[GH #20](https://github.com/vaam-store/image-resizer/issues/20)): a
+`bench-baseline` job saves a `main`-branch baseline on every push to
+`main`, and a `bench` job on every PR compares against it and fails if any
+benchmark regresses past a 15% threshold
+(`.github/scripts/bench_gate.py`), posting a percentile table as a PR
+comment. `src/bin/benchmark.rs` is a separate end-to-end HTTP load-test
+binary against a running server, not a criterion bench - see its own
+`--help`. `.bench-baseline/` in the repo root records past criterion runs
+(with staleness caveats - read `BASELINE.md` there before diffing a fresh
+run against it and attributing the whole delta to your own change).
+
+### Three-way harness against imgproxy (`bench-imgproxy/`)
+
+A `docker compose`-based harness that runs `imgproxy`, `emgr` on
+`local_fs`, and `emgr` on `s3`/MinIO side by side against the same
+generated image corpus, driven by [k6](https://k6.io/). This is
+end-to-end (over HTTP, through Docker) rather than in-process, so it
+measures something criterion can't - including the local_fs-vs-S3
+storage-backend difference. Not run in CI; see
+[`bench-imgproxy/README.md`](https://github.com/vaam-store/image-resizer/blob/main/bench-imgproxy/README.md)
+for the full quick start and what the harness does and does not prove -
+its own `results/` directory (gitignored) holds past run output.
 
 ## Test coverage
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,59 +1,163 @@
 # Installation
 
-This guide will help you install and run the Image Resize Service.
+This guide gets `emgr` running locally - from a fresh clone, through the two
+startup checks that fail closed by design, to a working `/health` response.
 
 ## Prerequisites
 
-- [Rust](https://www.rust-lang.org/tools/install) 1.70 or later
-- [Docker](https://docs.docker.com/get-docker/) (optional, for containerized deployment)
-- [Kubernetes](https://kubernetes.io/docs/setup/) (optional, for Kubernetes deployment)
-- [Helm](https://helm.sh/docs/intro/install/) (optional, for Helm chart deployment)
+- A stable Rust toolchain. `Cargo.toml` sets `edition = "2024"`, which needs
+  Rust 1.85 or newer; CI builds against whatever `dtolnay/rust-toolchain@stable`
+  currently resolves to, so there's no lower pin to target beyond that.
+- `nasm`, **only when building on x86_64** (Linux/macOS amd64). It's needed
+  by `mozjpeg-sys` for libjpeg-turbo's x86 SIMD path. aarch64 (Apple
+  Silicon, arm64 Linux) doesn't need it - it uses its own NEON path. If
+  you're on x86_64 and skip it, the build either fails outright or falls
+  back to scalar C, quietly losing most of the mozjpeg decode speedup.
+- [Docker](https://docs.docker.com/get-docker/) and
+  [Docker Compose](https://docs.docker.com/compose/) v2 (optional - see
+  [Docker deployment](../deployment/docker.md)).
+- [Kubernetes](https://kubernetes.io/docs/setup/) and
+  [Helm](https://helm.sh/docs/intro/install/) 3 (optional - see the
+  [Helm chart](../deployment/helm-chart.md) guide).
 
-## Local Development Setup
-
-### Clone the Repository
+## Clone the repository
 
 ```bash
 git clone https://github.com/vaam-store/image-resizer.git
 cd image-resizer
 ```
 
-### Build and Run Locally
+A fresh clone builds with plain `cargo build` - no code generation step,
+no Docker step. `make init` (an old OpenAPI-codegen bootstrap) and the
+`openapi.yaml`/`packages/gen-server` it drove no longer exist: the HTTP
+router in `src/modules/api`, `src/modules/router` and `src/modules/url` is
+hand-written (removed in [GH #53](https://github.com/vaam-store/image-resizer/issues/53)).
 
-```bash
-# Build the project
-cargo build
+## Pick a feature set
 
-# Run the service
-cargo run
+`Cargo.toml` sets `default = []`. That's deliberate, but it means a bare
+`cargo build` compiles fine and then the binary refuses to start:
+
+```text
+Error: No storage features are enabled
 ```
 
-The service will be available at `http://localhost:8080`.
+Every build must name at least one storage backend explicitly, from
+`Cargo.toml`'s `[features]`:
 
-## Docker Deployment
+| Feature | What it does |
+|---|---|
+| `local_fs` | Store resized images on local disk. No external dependency - the easiest way to get started. |
+| `s3` | Store resized images in S3 or an S3-compatible service (MinIO). Needs a reachable endpoint - see [Docker deployment](../deployment/docker.md) for a MinIO-backed `compose.yaml` setup. |
+| `in_memory` | An in-process cache. Only reachable in this crate's own test builds ([GH #39](https://github.com/vaam-store/image-resizer/issues/39)) - selecting it in a release build falls through to the same "no storage backend" error above. Useful for `cargo test`, not for running the service. |
+| `otel` | OpenTelemetry tracing + a Prometheus `/metrics` endpoint. Combine with a storage feature, e.g. `local_fs,otel`. |
 
-### Using Docker Compose
-
-The easiest way to get started is using Docker Compose:
-
-```bash
-# Start the service
-docker-compose up -d
-
-# Check logs
-docker-compose logs -f
-```
-
-### Building and Running the Docker Image
+You can enable more than one storage feature in the same binary - see
+`STORAGE_TYPE` in [Configuration](configuration.md) for how the backend is
+then chosen at runtime.
 
 ```bash
-# Build the Docker image
-docker build -t image-resizer:latest .
+# Build with local filesystem storage
+cargo build --features local_fs
 
-# Run the container
-docker run -p 8080:8080 image-resizer:latest
+# Build with S3/MinIO storage
+cargo build --features s3
+
+# Build with local filesystem storage plus tracing/metrics
+cargo build --features local_fs,otel
 ```
 
-## Kubernetes Deployment
+`--no-default-features` is a no-op today (`default = []`), but CI always
+passes it explicitly so these stay genuinely isolated feature sets if a
+non-empty default is ever added later - worth doing the same locally.
 
-See the [Helm Chart](../deployment/helm-chart.md) documentation for details on deploying to Kubernetes.
+## Configure the two startup checks
+
+Both of these are enforced in `ApiService::create` at process startup, not
+per-request - a misconfigured deployment is refused outright rather than
+serving broken responses.
+
+### 1. Signed URLs (always required)
+
+Signing is the default, not opt-in ([GH #27](https://github.com/vaam-store/image-resizer/issues/27)).
+`emgr` refuses to start unless **both** `SIGNING_KEY` and `SIGNING_SALT`
+(hex-encoded) are set, **or** you explicitly opt out:
+
+```bash
+# Real key/salt (recommended, even for local dev)
+export SIGNING_KEY=$(openssl rand -hex 32)
+export SIGNING_SALT=$(openssl rand -hex 16)
+
+# Or, explicitly opt out for local development only:
+export ALLOW_UNSIGNED_REQUESTS=true
+```
+
+With `ALLOW_UNSIGNED_REQUESTS=true`, a request whose signature segment is
+the literal `unsigned` bypasses verification. It never weakens
+verification of a real signature - it only widens that one escape path.
+See [Configuration](configuration.md) and the
+[API reference](../user-guide/api-reference.md) for the signed-URL format,
+and [Examples](../user-guide/examples.md) for computing a real signature.
+
+### 2. `/metrics` authentication (`otel` builds only)
+
+If (and only if) the binary was built with `--features otel`, a second,
+independent check applies: `emgr` refuses to start unless
+`METRICS_AUTH_TOKEN` is set, **or** you explicitly opt out with
+`ALLOW_UNAUTHENTICATED_METRICS=true` ([GH #77](https://github.com/vaam-store/image-resizer/issues/77)).
+`/metrics` exposes request rates, cache hit ratios, error counts and
+latency histograms - reconnaissance-grade information about the service's
+traffic - so this fails closed exactly like signing does.
+
+```bash
+export METRICS_AUTH_TOKEN=$(openssl rand -hex 32)
+# Or: export ALLOW_UNAUTHENTICATED_METRICS=true
+```
+
+A non-`otel` build has no `/metrics` endpoint at all and doesn't require
+either variable. `/health` is unauthenticated on both builds - orchestrator
+probes can't easily carry a secret.
+
+## Run it
+
+```bash
+export LOCAL_FS_STORAGE_PATH=./data/images
+export ALLOW_UNSIGNED_REQUESTS=true   # or the real SIGNING_KEY/SIGNING_SALT above
+
+cargo run --features local_fs --bin emgr
+```
+
+`--bin emgr` is required - the crate also ships `healthcheck` (the Docker
+`HEALTHCHECK` binary) and `benchmark` (an HTTP load-test tool, see
+[Testing](../development/testing.md)), so `cargo run` alone can't guess
+which one you mean.
+
+By default the service listens on `0.0.0.0:3000` (`HOST` / `PORT`):
+
+```bash
+curl -i http://localhost:3000/health
+```
+
+```text
+HTTP/1.1 200 OK
+content-type: text/plain; charset=utf-8
+...
+
+OK
+```
+
+For the full environment variable reference (storage backend selection,
+the SSRF source-fetch guard, resolution limits, performance tuning,
+observability), see [Configuration](configuration.md) - it's generated
+against `src/modules/env/env.rs` and CI-checked for drift.
+
+## Docker
+
+See [Docker deployment](../deployment/docker.md) for the four build
+targets (`fs_deploy`, `fs_otel_deploy`, `s3_deploy`, `s3_otel_deploy`) and
+`compose.yaml`.
+
+## Kubernetes
+
+See the [Helm chart](../deployment/helm-chart.md) guide for deploying to
+Kubernetes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,36 +1,77 @@
-# Image Resize Service
+# EmgR
 
-Welcome to the documentation for the Image Resize Service, a high-performance image resizing API built with Rust.
+Welcome to the documentation for **EmgR**, a high-performance, imgproxy-compatible
+image resizing service built in Rust. It fetches a source image over HTTP(S),
+resizes/transforms it according to a signed URL, caches the result, and
+redirects the caller to it.
 
 ## Features
 
-- Fast image resizing with multiple storage backends
-- Caching for improved performance
-- Metrics and health monitoring
-- Kubernetes deployment support via Helm
-- Configurable storage options (S3, local filesystem, in-memory)
+- On-the-fly resizing via an [imgproxy-compatible signed URL scheme](user-guide/api-reference.md) -
+  resize/crop, gravity, quality, blur, grayscale, watermarks and named presets.
+- JPEG, PNG, WebP (lossy and lossless), AVIF and animated GIF/WebP output,
+  through a SIMD resampler (`fast_image_resize`) and a mozjpeg-backed JPEG
+  decode/encode path (DCT-scaled decode, progressive/subsampling control).
+- Pluggable storage backends selected at **compile time** via Cargo feature
+  flags: local filesystem, S3/MinIO, or in-memory (test builds only).
+- HMAC-signed URLs **on by default**, an SSRF-guarded source fetcher, and
+  configurable resolution/output limits.
+- OpenTelemetry tracing and a bearer-token-protected `/metrics` endpoint,
+  available behind the `otel` feature.
+- Kubernetes deployment via a Helm chart (or a Knative Service chart for
+  serverless setups).
 
-## Quick Start
+## Before you start
+
+Two things surprise newcomers, and both are deliberate:
+
+1. **`emgr` has no default storage backend.** `Cargo.toml` sets
+   `default = []`, so a plain `cargo build` compiles but the resulting
+   binary refuses to start ("No storage features are enabled"). Every
+   build must name at least one of `local_fs`, `s3`, or `in_memory`
+   explicitly.
+2. **The service fails closed at startup** unless signed URLs are
+   configured (`SIGNING_KEY` + `SIGNING_SALT`) or you explicitly opt out
+   with `ALLOW_UNSIGNED_REQUESTS=true`. A build with the `otel` feature
+   adds a second, independent check for `/metrics`.
+
+See [Getting Started → Installation](getting-started/installation.md) for
+the full explanation, the exact commands, and every feature combination CI
+tests.
+
+## Quick start
 
 ```bash
-# Clone the repository
 git clone https://github.com/vaam-store/image-resizer.git
 cd image-resizer
 
-# Build and run with Docker Compose
-docker-compose up -d
+# local_fs storage, signing turned off for local dev only - see
+# Installation for the signed-URL alternative. --bin is required because
+# the crate also ships `healthcheck` and `benchmark` binaries.
+LOCAL_FS_STORAGE_PATH=./data/images ALLOW_UNSIGNED_REQUESTS=true \
+  cargo run --no-default-features --features local_fs --bin emgr
 ```
 
-Visit the [Getting Started](getting-started/installation.md) section for more detailed instructions.
+```bash
+curl -i http://localhost:3000/health
+```
 
-## API Overview
+## API overview
 
-The Image Resize Service provides a RESTful API for resizing and manipulating images. See the [API Reference](user-guide/api-reference.md) for detailed documentation.
+The service exposes a RESTful, imgproxy-compatible resize endpoint plus a
+download endpoint for already-cached results. See the
+[API Reference](user-guide/api-reference.md) for the full URL grammar,
+status codes and processing options, and [Examples](user-guide/examples.md)
+for computing a valid signature in Python/JavaScript/bash.
 
 ## Architecture
 
-This service is built with a modular architecture using Rust for high performance. Learn more about the [architecture](architecture/overview.md) and [components](architecture/components.md).
+The service is a hand-written Axum router (no OpenAPI code generation) over
+a small set of modular Rust services. See the
+[architecture overview](architecture/overview.md) and
+[components](architecture/components.md) pages.
 
 ## Deployment
 
-The service can be deployed using [Docker](deployment/docker.md) or [Kubernetes with Helm](deployment/helm-chart.md).
+Run it with [Docker](deployment/docker.md), or deploy it to Kubernetes with
+the [Helm chart](deployment/helm-chart.md).

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -1,19 +1,48 @@
 # API Reference
 
 `emgr` exposes a small HTTP API for resizing and then downloading images.
-This page is the source of truth for it - there is no `openapi.yaml` any
-more. [GH #53](https://github.com/vaam-store/image-resizer/issues/53)
-removed OpenAPI code generation and replaced the query-parameter
-`GET /api/images/resize?...` endpoint with an imgproxy-compatible signed
-URL path, implemented under
+This page is the source of truth for it. There is no OpenAPI spec and no
+generated client any more — [GH #53](https://github.com/vaam-store/image-resizer/issues/53)
+deleted `openapi.yaml` and the codegen pipeline that consumed it, replacing
+the old query-parameter `GET /api/images/resize?...` endpoint with an
+imgproxy-compatible signed URL path (implemented under
 [#27](https://github.com/vaam-store/image-resizer/issues/27) alongside HMAC
-signing (see the [rationale in ADR 0002](https://github.com/vaam-store/image-resizer/blob/main/adr/0002-url-api-shape.md)).
-This is a hard cutover: the old query-parameter route is gone, not aliased.
+signing — see the [rationale in ADR 0002](https://github.com/vaam-store/image-resizer/blob/main/adr/0002-url-api-shape.md)).
+This was a hard cutover: the old query-parameter route is gone, not
+aliased, and there is nothing left to regenerate a client from.
 
 ## Base URL
 
-There is no versioned path prefix (no `/api/v1`) - every route below is
+There is no versioned path prefix (no `/api/v1`) — every route below is
 relative to the service root, e.g. `http://localhost:3000`.
+
+## The most important divergence from imgproxy: `g:` is grayscale, not gravity
+
+In imgproxy, `g:` is the **gravity** option. In `emgr`, `g:` is
+**grayscale** — gravity is `gr:` instead.
+
+This isn't a typo or an oversight; it's a deliberate, recorded decision
+([ADR 0002, "Amendment 2026-08-20: the `g:` option collision"](https://github.com/vaam-store/image-resizer/blob/main/adr/0002-url-api-shape.md#amendment-2026-08-20-the-g-option-collision-73)).
+`g:` was already grayscale in this service before anyone noticed imgproxy
+uses the same prefix for gravity, and the repository owner chose to keep
+`g:` as grayscale rather than break it.
+
+**Practical consequence, verified against `parse_bool`/the `g` match arm
+(`options.rs:374-377`, `709-718`):** `g:` here accepts exactly one
+argument, and it must parse as a boolean (`true`/`false`/`1`/`0`). Every
+real imgproxy gravity token (`ce`, `no`, `so`, `ea`, `we`, `noea`, `nowe`,
+`soea`, `sowe`, `sm`, `obj`, `objw`, or a 3-argument `fp:{x}:{y}`) fails
+that boolean parse — so an imgproxy URL that tries to use `g:` for gravity
+does not get silently misread into a different, wrong result; it gets
+rejected with `400 Bad Request`. That's a real, verified improvement on
+the "silently misread" outcome the collision could in principle produce —
+but it's still a hard migration break, not a compatible fallback: any
+client library that assumes imgproxy's `g:` means gravity gets a `400`
+instead of the anchored crop it expected, and has to be changed to send
+`gr:` for gravity while reserving `g:` for grayscale. If you are migrating
+from imgproxy and use gravity at all, rewrite `g:` to `gr:` first.
+
+Every other short option code below matches imgproxy's own vocabulary.
 
 ## Endpoints
 
@@ -24,61 +53,347 @@ GET /{signature}/{processing_options}/{plain|base64 source}.{extension}
 ```
 
 Fetches the source image, resizes/transforms it, stores the result, and
-redirects to it (`301`) - it does not stream the resized bytes back
+redirects to it (`301`) — it does not stream the resized bytes back
 directly (see [Download a resized image](#download-a-resized-image)
-below). Modeled on imgproxy's own URL shape closely enough that a client
-library written for imgproxy produces something this service accepts.
+below).
 
 #### `{signature}`
 
 Either:
 
 - A URL-safe base64 (no padding) HMAC-SHA256 signature over
-  `salt || {processing_options}/{source}.{extension}` (the request path
+  `salt || {processing_options}/{source}.{extension}` — the request path
   *after* the signature segment, leading `/` included, exactly as received
-  on the wire), keyed by `SIGNING_KEY`/`SIGNING_SALT`
+  on the wire, still percent-encoded — keyed by `SIGNING_KEY`/`SIGNING_SALT`
   ([Configuration](../getting-started/configuration.md#signed-urls)).
-  Verified in constant time.
-- The literal string `unsigned` - only accepted when the operator has set
-  `ALLOW_UNSIGNED_REQUESTS=true`. Refused with `403` otherwise. Signing is
-  the default; this is a local-development escape hatch, not a normal mode.
+  Computed as `base64url_nopad(HMAC-SHA256(key, salt || signed_path))`
+  (`src/modules/signing/verify.rs:9-20`) and verified in constant time
+  (`verify_signature`, `src/modules/signing/verify.rs:31-43`).
+- The literal string `unsigned` — only accepted when the operator has set
+  `ALLOW_UNSIGNED_REQUESTS=true`. Refused with `403` otherwise
+  (`src/modules/api/resize.rs:90-108`).
 
 An invalid, missing, or (when not explicitly allowed) `unsigned` signature
-returns `403 Forbidden` before any further parsing happens.
+returns `403 Forbidden` *before* the processing-options grammar is parsed
+at all — an unauthenticated caller never gets parse-error feedback as an
+oracle (`src/modules/api/resize.rs:85-89`).
+
+**This service fails closed at startup, not per-request.** If
+`SIGNING_KEY`/`SIGNING_SALT` are unset (or invalid hex) *and*
+`ALLOW_UNSIGNED_REQUESTS` is not explicitly `true`, the process refuses to
+start at all, rather than coming up and serving `403` to every caller
+(`SigningConfig::from_env`, `src/modules/signing/config.rs:42-68`). Signing
+is the default; `unsigned` is a local-development escape hatch, never a
+fallback an operator accidentally ends up running in production.
 
 #### `{processing_options}`
 
-Zero or more `/`-delimited segments, each `code:arg1:arg2:...`, mirroring
-imgproxy's own short option codes:
+Zero or more `/`-delimited segments, each `code:arg1:arg2:...`. An unknown
+option code, wrong argument count, or an out-of-range value returns
+`400 Bad Request` (`UrlParseError::UnknownOption` /
+`InvalidOptionValue`, `src/modules/url/mod.rs:39-42`).
 
-| Code | Meaning | Example |
-|---|---|---|
-| `rs` | Resize: `rs:{type}:{width}:{height}`. `{type}` is accepted for imgproxy URL compatibility but doesn't currently change behaviour (resize mode is derived from which of width/height are set - see below). `0` for either dimension means "not set". | `rs:fill:300:300` |
-| `q` | Output encode quality, `0`-`100`. | `q:80` |
-| `bl` | Gaussian blur sigma. | `bl:5` |
-| `g` | Grayscale: `true`/`false`/`1`/`0`. | `g:true` |
-| `el` | Enlarge: allow upscaling past the source resolution (`true`/`false`/`1`/`0` as `1`/`0`). Default `0` (refused) - see [GH #36](https://github.com/vaam-store/image-resizer/issues/36). | `el:1` |
+##### Simple options
 
-An unknown option code, wrong argument count, or a value out of range
-returns `400 Bad Request`.
+Every option below is parsed in `src/modules/url/options.rs`; the line
+range for each `match` arm is cited so this table can be re-verified
+against the code later.
 
-Width/height resize behaviour, unchanged from before #53: both set resizes
-and crops to fill exactly that box; only one set resizes preserving aspect
-ratio; neither set leaves dimensions untouched. Output never exceeds the
-source's resolution unless `el:1` opts in.
+| Code | Syntax | Default | What it does | imgproxy equivalent |
+|---|---|---|---|---|
+| `rs` | `rs:{type}:{width}:{height}` | no resize | Resize per `{type}` once both dimensions are non-zero; a lone width or height resizes preserving aspect ratio. `{type}` is one of `fit`/`fill`/`force`/`auto` — see [Resize type (`rs:`)](#resize-type-rs) below. `0` for either dimension means "not set". (`options.rs:220-236`) | Same option, same name. |
+| `q` | `q:{0-100}` | encoder default (JPEG 85 / WebP 80) | Global output encode quality. Overridden per-format by `fq:`. (`options.rs:237-240`) | Same. |
+| `fq` | `fq:{format1}:{q1}:{format2}:{q2}:...` | — | Per-format quality override, redefining `q:` for one or more formats in the same request. Only `jpg`/`jpeg` and `webp` are accepted — `fq:png:N` is a `400`, because PNG output here has no continuous quality knob (fixed `CompressionType::Best`). Repeating a format lets the later pair win. (`options.rs:241-284`) | Same option (`format_quality`); imgproxy also silently ignores `png`/other unsupported formats — this service rejects them instead. |
+| `webpo` | `webpo:{compression}` | lossy | WebP compression mode: `lossy` or `lossless` only. **Only the first of imgproxy's three `webp_options` slots is implemented** — `smart_subsample` and `preset` are rejected (`400`) if supplied, not silently ignored, because the underlying `webp` crate has no equivalent knob and no `mixed` mode either. (`options.rs:285-315`) | Partial: imgproxy's `webp_options`/`webpo:{compression}:{smart_subsample}:{preset}`. |
+| `jpgo` | `jpgo:{progressive}:{no_subsample}` | deployment default | JPEG encode tuning. **Only the first two of imgproxy's six slots are implemented** — `trellis_quant`, `overshoot_deringing`, `optimize_scans`, `quant_table` are rejected (`400`) rather than silently ignored, since `mozjpeg::Compress` has no direct equivalent for them. Each of the two implemented slots may be left blank (`jpgo:1:`) to keep this deployment's configured default (`JPEG_PROGRESSIVE`/`JPEG_NO_SUBSAMPLING`). See [subsection](#jpeg-tuning-jpgo) below. (`options.rs:316-352`) | Partial: imgproxy's `jpeg_options`/`jpgo:{progressive}:{no_subsample}:{trellis_quant}:{overshoot_deringing}:{optimize_scans}:{quant_table}`. |
+| `mb` | `mb:{bytes}` | none (no limit) | Maximum encoded output size in bytes; the encoder iteratively lowers quality until the output fits (or a bounded search is exhausted). `0` means "not set". **Only applied to JPEG output** — WebP, PNG, AVIF and GIF ignore it entirely (`encode_single_image`, `src/services/image/handler.rs:911-926`). | Diverges: imgproxy's `max_bytes` also applies to WebP; this service's does not. |
+| `bl` | `bl:{sigma}` | none | Gaussian blur sigma, applied after resize/rotate/flip. (`options.rs:370-373`) | Same. |
+| `g` | `g:{true\|false\|1\|0}` | none (off) | **Grayscale** — see the [callout above](#the-most-important-divergence-from-imgproxy-g-is-grayscale-not-gravity). (`options.rs:374-377`) | **Diverges — imgproxy's `g:` is gravity.** |
+| `el` | `el:{true\|false\|1\|0}` | `false` | Enlarge: permit upscaling past the source resolution. Refused by default ([GH #36](https://github.com/vaam-store/image-resizer/issues/36)). | Same. |
+| `bg` | `bg:{R}:{G}:{B}` or `bg:{hex}` | opaque white | Background colour used to flatten alpha for formats with no alpha channel (JPEG) and to normalise fully-transparent pixels for formats that keep alpha (PNG/WebP/AVIF/GIF). `{hex}` accepts 3- or 6-digit hex, no leading `#`. (`options.rs:382-387`, `params.rs:348-359`) | Same, except imgproxy's default is "disabled" (no flatten); this service always flattens. |
+| `ar` | `ar:{true\|false\|1\|0}` | `true` (on) | Auto-rotate per the source's EXIF `Orientation` tag, before any resize/crop. Note the default is `true` here — unlike every other boolean option on this list. (`options.rs:395-398`, `params.rs:361-379`) | Same, including the `true` default. |
+| `rot` | `rot:{angle}` | `0` | Rotate clockwise by `{angle}` degrees, applied *after* resize. Must be a multiple of 90 (negative allowed, normalised via `rem_euclid(360)`). (`options.rs:448-451`) | Same. |
+| `fl` | `fl:{horizontal}:{vertical}` | `0:0` | Flip. Each slot is an independent boolean; `fl:1` flips only horizontally. Applied immediately after `rot:`. (`options.rs:452-469`) | Same. |
+| `ex` | `ex:{true\|false\|1\|0}` | `false` | Extend: pad the resized image up to the full requested `width`x`height` (centred, background-filled) if the resize would otherwise come out smaller. No-op unless both `width` and `height` are set. **Only the boolean argument is accepted** — imgproxy's optional trailing `:gravity` argument is rejected (`400`), since only centre-gravity extend is implemented. (`options.rs:479-487`) | Partial: imgproxy's `extend`/`ex:{enabled}:{gravity}` — the gravity slot isn't supported here. |
+| `z` | `z:{zoom}` or `z:{zoom_x}:{zoom_y}` | `1.0:1.0` | Multiplies an axis's requested size before resize. A single argument sets both axes. **Only scales an axis that already has an explicit `width`/`height` set** — unlike imgproxy, this service cannot zoom the "natural" source size with no explicit dimension. (`options.rs:494-500`, `effective_resize_box`, `src/services/image/handler.rs:2413-2417`) | Diverges: imgproxy can also scale with no explicit width/height; this service can't. |
+| `dpr` | `dpr:{value}` | `1.0` | Device-pixel-ratio multiplier, same mechanics and same "only scales an axis with an explicit dimension" narrowing as `z:` above — combined multiplicatively with it on the same axis. (`options.rs:501-505`) | Diverges the same way `z:` does. |
+| `mw` | `mw:{width}` | none | Minimum *resulting* width — a floor, not a cap. **Not gated by `el:`**: it can force upscaling past the source even with `el:0`, matching imgproxy's own behaviour. (`options.rs:506-512`) | Same (`min-width`). |
+| `mh` | `mh:{height}` | none | Same as `mw`, for height. (`options.rs:513-516`) | Same (`min-height`). |
+
+##### Resize type (`rs:`)
+
+```
+rs:{type}:{width}:{height}
+```
+
+`{type}` is one of:
+
+| Type | Behaviour |
+|---|---|
+| `fit` (default) | Scale to fit *inside* the box, preserving aspect ratio — neither output dimension exceeds the requested one. |
+| `fill` | Scale to *cover* the box preserving aspect ratio, then crop the overflow, anchored by [`gr:`](#gravity-gr) (default centre). |
+| `force` | Stretch to exactly `width`x`height`, ignoring aspect ratio. |
+| `auto` | `fill` when the source and requested boxes share orientation (both landscape-or-square, or both portrait); `fit` otherwise. |
+
+An empty type slot (`rs::800:600`) also defaults to `fit`. An unrecognised
+type is rejected with `400`, not silently substituted
+(`ResizeType::from_str`, `src/models/params.rs:113-133`; dispatch in
+`src/services/image/handler.rs:1003-1042`).
+
+##### Explicit crop (`c:`)
+
+```
+c:{width}:{height}[:{gravity_tokens...}]
+```
+
+Crops the *decoded, autorotated, trimmed* image to `{width}`x`{height}`
+before any resize math runs (`process_image_blocking_with_limits`,
+`src/services/image/handler.rs:607-620`). Each dimension follows a
+three-way convention (`options.rs:788-812`, `parse_crop_dimension`):
+
+- `0` — use the full source dimension on that axis (no crop on that axis).
+- `>= 1` — absolute pixel size.
+- `(0, 1)` — a fraction of the source dimension on that axis.
+
+An optional trailing gravity anchors the crop within the source image,
+using the same token vocabulary as [`gr:`](#gravity-gr) below (`ce`, `no`,
+`so`, `ea`, `we`, `noea`, `nowe`, `soea`, `sowe`, or `fp:{x}:{y}`). If
+omitted, the crop inherits whatever `gr:` sets elsewhere in the URL —
+order-independent, since resolution happens after the whole URL has been
+parsed (`options.rs:67-72`, `569-573`).
+
+##### Gravity (`gr:`)
+
+```
+gr:{type}
+gr:fp:{x}:{y}
+```
+
+Anchors two things: the overflow-crop side of `rs:fill`/`rs:auto`, and an
+explicit `c:` crop that doesn't name its own gravity. `{type}` is one of
+`ce` (centre, default), `no`, `so`, `ea`, `we`, `noea`, `nowe`, `soea`,
+`sowe`, or `fp:{x}:{y}` — a focus point, `x`/`y` fractions in `[0, 1]` of
+the image (`options.rs:826-862`).
+
+Two divergences from imgproxy, both deliberate:
+
+- **This is `gr:`, not `g:`** — see the [callout above](#the-most-important-divergence-from-imgproxy-g-is-grayscale-not-gravity).
+- **Smart/saliency gravity (`sm`) and object-detection gravity (`obj`,
+  `objw`, imgproxy Pro) are rejected with `400`**, not silently aliased to
+  `ce` or any other gravity — there is no saliency/object-detection
+  implementation behind them (`options.rs:820-825`, `858-860`;
+  `Gravity`'s doc comment, `src/models/params.rs:149-155`).
+- **No `x_offset`/`y_offset` nudge** on the directional/corner/centre
+  variants. imgproxy lets every gravity type take an extra offset pair;
+  this service only exposes an offset-like mechanism for `fp:{x}:{y}`
+  (where the fraction *is* the point) — `gr:no:10:20` is rejected, it is
+  not "north, nudged by 10x20" (`Gravity`'s doc comment,
+  `src/models/params.rs:141-148`).
+
+##### Watermark (`wm:` and friends)
+
+```
+wm:{opacity}[:{position}[:{x_offset}[:{y_offset}[:{scale}]]]]
+wmu:{base64url-encoded-watermark-url}
+wms:{width}:{height}
+wmr:{angle}
+wmsh:{sigma}
+```
+
+**Only image watermarking is implemented — imgproxy's text watermarking
+has no equivalent here at all** (no `wmt:`/text-drawing option exists in
+the grammar).
+
+`wm:` is what actually enables watermarking; every other field below is a
+modifier that has no effect unless `wm:` is also present
+(`options.rs:124-130`). Composited after resize/rotate/flip/grayscale/blur
+but before the alpha-flatten/normalise stage, so the watermark's own alpha
+is correctly composited rather than slipping past it
+(`src/services/image/handler.rs:727-741`).
+
+| Field | Syntax | Default | Meaning |
+|---|---|---|---|
+| Opacity (required) | `wm:{opacity}` | — | Final opacity, clamped to `[0, 1]`. |
+| Position | `wm:{opacity}:{position}` | `ce` | One of `ce`, `no`, `so`, `ea`, `we`, `noea`, `nowe`, `soea`, `sowe`. **Tiling modes `re` (repeat) and `ch` (chessboard) are documented by imgproxy but not implemented** — rejected with `400` like any other unsupported value (`options.rs:647-671`). |
+| X offset | `wm:{opacity}:{position}:{x_offset}` | `0` | From `position`'s anchor. `>= 1.0` magnitude is absolute pixels; smaller is a fraction of the base image's width. |
+| Y offset | `wm:{opacity}:{position}:{x}:{y_offset}` | `0` | Same convention, against height. |
+| Scale | `wm:{opacity}:{position}:{x}:{y}:{scale}` | `0` (no scaling) | Watermark size as a fraction of the base image, fit preserving the watermark's own aspect ratio. |
+| Source URL | `wmu:{base64url}` | this deployment's `WATERMARK_URL` | Per-request watermark image, decoded here; SSRF-validated at fetch time through the same guard as the main source URL. |
+| Size | `wms:{width}:{height}` | natural size | Explicit watermark dimensions; either may be `0` to derive from the other via the watermark's own aspect ratio. Always fit, never stretched. |
+| Rotate | `wmr:{angle}` | `0` | Clockwise degrees. |
+| Shadow | `wmsh:{sigma}` | none | Gaussian-blur sigma for a drop-shadow silhouette behind the watermark. |
+
+Every trailing slot in `wm:` may be omitted (a shorter segment) or left
+blank (`wm:0.5::10`) to keep its default (`options.rs:610-645`).
+
+##### JPEG tuning (`jpgo:`)
+
+```
+jpgo:{progressive}:{no_subsample}
+```
+
+- `progressive` (`true`/`false`/`1`/`0`) — encode JPEG progressively
+  instead of baseline sequential.
+- `no_subsample` — encode chroma at full resolution (4:4:4) instead of
+  this service's default 4:2:2.
+
+Either slot left blank keeps this deployment's configured default
+(`JPEG_PROGRESSIVE`/`JPEG_NO_SUBSAMPLING`, resolved in
+`encode_single_image`, `src/services/image/handler.rs:903-908`). imgproxy's
+remaining four slots (`trellis_quant`, `overshoot_deringing`,
+`optimize_scans`, `quant_table`) are **not implemented and are rejected
+with `400`** if a third argument or beyond is present — there is no
+equivalent knob in the `mozjpeg` encoder this service routes JPEG through.
+
+##### Trim (`t:`)
+
+```
+t:{threshold}:{color}:{equal_hor}:{equal_ver}
+```
+
+Removes uniform-colour borders. Always the *first* geometry operation
+applied, right after decode/autorotate and before crop/resize
+(`src/services/image/handler.rs:596-605`).
+
+- `threshold` (required) — colour-similarity tolerance, compared as the
+  maximum per-channel (Chebyshev) distance from the target colour. This is
+  a simpler, more predictable metric than imgproxy's own perceptual
+  "smart" trim.
+- `color` (optional hex, no leading `#`) — the colour to treat as
+  background. Defaults to auto-detecting from the image's own top-left
+  corner pixel — a deliberately simpler stand-in for imgproxy's
+  multi-corner smart detection.
+- `equal_hor` / `equal_ver` (optional booleans, default `false`) — when
+  set, the two opposing trim amounts on that axis are clamped to their
+  minimum, so only a symmetric amount is cut.
+
+##### Padding (`pd:`)
+
+```
+pd:{top}:{right}:{bottom}:{left}
+```
+
+CSS-shorthand-style cascading fallback, reproducing imgproxy's exact
+positional-with-fallback parse (`options.rs:925-971`):
+
+- `right` falls back to `top` when omitted/empty.
+- `bottom` falls back to `top` (not `right`) when omitted/empty.
+- `left` falls back to `right`'s already-resolved value when omitted/empty.
+
+So `pd:10` pads every side by 10, `pd:10:20` pads top/bottom 10 and
+left/right 20, `pd:10:20:30` pads top 10, left/right 20, bottom 30 — same
+as CSS's 1/2/3/4-value shorthand, even though the underlying parse is
+positional, not a value-count switch. At least the `top` argument must be
+present. Applied after `ex:` (extend), always enlarging the canvas via a
+`background`-coloured fill.
+
+##### Presets (`pr:`) and the processing-option allowlist
+
+```
+pr:{name}[:{name2}...]
+```
+
+`pr:` is parsed in `src/modules/url/mod.rs` (`parse_with_config`,
+`mod.rs:119-159`), not in `options.rs` like every option above — it's
+expanded into the option segments it names *before* `ProcessingOptions`
+ever sees them, so it isn't a "code" in the same sense as `rs`/`q`/etc.
+
+- `PRESETS` (env var; imgproxy: `IMGPROXY_PRESETS`) configures named,
+  reusable option-segment lists: `thumbnail=rs:fill:300:300/q:80,default=el:1`.
+  See `src/modules/url/presets.rs`.
+- A preset named `default` is applied automatically ahead of every
+  request's own segments, even when the request never names a preset —
+  overridable by a later explicit option in the same request, since
+  segments apply in order.
+- A `pr:{name}` segment referencing an unknown preset returns `400`
+  (`UnknownPreset`).
+- Presets cannot reference other presets — rejected at config-load time.
+- `ALLOWED_PROCESSING_OPTIONS` (env var; imgproxy:
+  `IMGPROXY_ALLOWED_PROCESSING_OPTIONS`) is a comma-separated allowlist of
+  option codes permitted **directly** in a request URL. It does **not**
+  apply to options used *inside* a preset's own definition — this is what
+  lets an operator hand out a restricted set of presets while forbidding
+  the raw options they're built from. An option excluded by the allowlist
+  returns `400` (`OptionNotAllowed`).
+
+See [Configuration](../getting-started/configuration.md) for how to set
+both env vars.
+
+#### Processing pipeline order
+
+Several options interact, and the order they're applied in is not obvious
+from the URL alone — for example, `t:` (trim) always runs before `c:`
+(crop), and `rot:`/`fl:` run *after* resize, not before. This is the exact
+order `ImageService` applies them in
+(`src/services/image/handler.rs:490-968`):
+
+```mermaid
+flowchart TD
+    A["Decode source bytes<br/>(DCT-scaled for JPEG — decode_jpeg_scaled,<br/>handler.rs:2832)"] --> B["Autorotate<br/>(EXIF Orientation, ar: — handler.rs:592-594)"]
+    B --> C["Trim<br/>(t: — handler.rs:602-605)"]
+    C --> D["Explicit crop<br/>(c: — handler.rs:615-618)"]
+    D --> E["Resize<br/>(rs:/fit/fill/force/auto,<br/>zoom/dpr/enlarge/min-width/min-height —<br/>handler.rs:665-684)"]
+    E --> F["Rotate<br/>(rot: — handler.rs:1056)"]
+    F --> G["Flip<br/>(fl: — handler.rs:1057)"]
+    G --> H["Grayscale<br/>(g: — handler.rs:1060-1064)"]
+    H --> I["Blur<br/>(bl: — handler.rs:1066-1070)"]
+    I --> J["Extend<br/>(ex: — handler.rs:694-705)"]
+    J --> K["Padding<br/>(pd: — handler.rs:707-710)"]
+    K --> L["Watermark composite<br/>(wm: — handler.rs:736-741)"]
+    L --> M["Alpha flatten / normalise<br/>(bg: — handler.rs:767-801)"]
+    M --> N["Encode<br/>(q:/fq:/jpgo:/mb:/webpo:, format from<br/>the URL's .extension — handler.rs:847-965)"]
+```
+
+Two ordering consequences worth calling out explicitly:
+
+- Because trim runs before crop and crop runs before resize, `c:`'s
+  `width`/`height` are measured against the *trimmed* image, not the
+  original source.
+- Because `rot:`/`fl:` run *after* resize (matching imgproxy's own
+  pipeline), a 90°/270° rotation's effect on *which axis* gets which
+  requested dimension is already accounted for earlier, in the resize-box
+  calculation itself (`effective_resize_box`,
+  `src/services/image/handler.rs:2430-2497`) — the rotation you see here
+  is purely the final pixel rotation.
 
 #### `{plain|base64 source}.{extension}`
 
-The trailing `.{extension}` is mandatory (one of `jpg`, `jpeg`, `png`,
-`webp`) and always determines the output format - it is stripped from
-whatever precedes it, regardless of what that looks like.
+The trailing `.{extension}` is mandatory and always determines the output
+format — it is stripped from whatever precedes it, regardless of what that
+looks like. Recognised extensions
+(`KNOWN_EXTENSIONS`, `src/modules/url/source.rs:20`):
+
+| Extension | Output format | Notes |
+|---|---|---|
+| `jpg` / `jpeg` | JPEG | Encoded via `mozjpeg`/libjpeg-turbo (not `image`'s built-in encoder) so `jpgo:`/`mb:` actually reach the encoder. |
+| `png` | PNG | Fixed `CompressionType::Best`; no continuous quality knob (`fq:png:N` is rejected at parse time). |
+| `webp` | WebP | Via the `webp` crate; `webpo:lossless` for lossless. |
+| `avif` | AVIF | **Encode-only.** See the AVIF note below. |
+| `gif` | GIF | Supports decode and encode, including multi-frame animation when the source is itself animated and the request is `.gif` or `.webp`. |
+| `auto` | Negotiated | Not a real format — resolved against the request's `Accept` header before any `ResizeQuery` is built. See [`.auto` content negotiation](examples.md#auto-content-negotiation) in the examples. |
+
+An unrecognised or missing extension returns `400`
+(`src/modules/url/source.rs:84-97`).
+
+**AVIF is encode-only.** This service can *produce* AVIF output (via the
+pure-Rust `ravif` encoder, part of the `image` crate's default `avif`
+feature), but it **cannot decode an AVIF source** — that needs the
+separate `avif-native` cargo feature (`dav1d`, a C library), which is not
+enabled. An `.avif` *source* URL fails to decode; an `.avif` *output*
+extension works fine (`ImageFormat`'s doc comment,
+`src/models/params.rs:8-20`).
+
+**HEIC is not supported at all** — neither as a source nor as an output
+extension. `heic` is not in `KNOWN_EXTENSIONS`, so a `.heic` request
+returns `400` before any decode is attempted, and there is no HEIC decoder
+in this service's dependency tree regardless.
 
 - **Base64 form** (default): a single URL-safe base64 (no padding) segment
   encoding the source URL, e.g. `aHR0cHM6Ly9leGFtcGxlLmNvbS9waG90by5qcGc.webp`
   decodes to `https://example.com/photo.jpg` with output format `webp`.
 - **Plain form**: prefix with `plain/` followed by the literal,
   percent-encoded-where-needed source URL, e.g.
-  `plain/https://example.com/photo.jpg.webp` - the `.webp` at the very end
+  `plain/https://example.com/photo.jpg.webp` — the `.webp` at the very end
   is still the grammar's extension, not part of the URL, so the decoded
   source here is `https://example.com/photo.jpg`.
 
@@ -88,7 +403,7 @@ returns `400 Bad Request`.
 #### Worked example
 
 With `SIGNING_KEY=6d792d7369676e696e672d6b6579` and
-`SIGNING_SALT=6d792d73616c74` (hex for `my-signing-key` / `my-salt` -
+`SIGNING_SALT=6d792d73616c74` (hex for `my-signing-key` / `my-salt` —
 placeholders only, never use these for anything real), resizing
 `https://images.example.com/photo.jpg` to fill 300x300 at quality 80,
 output JPEG:
@@ -97,18 +412,18 @@ output JPEG:
 GET /de7BKgwO8wFeNZWRWgp3UB9jKwOkVoYM_eMKau2ECgw/rs:fill:300:300/q:80/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
 ```
 
-(Pinned by a test - `src/modules/signing/verify.rs`'s
-`documented_example` module - so this example can't silently drift from
+(Pinned by a test — `src/modules/signing/verify.rs`'s
+`documented_example` module — so this example can't silently drift from
 what the code actually computes.)
 
 #### Responses
 
 | Status | Meaning |
 |---|---|
-| `301 Moved Permanently` | Resize succeeded. `Location` header points at the [download endpoint](#download-a-resized-image) for the result - never a redirect back to the caller-supplied source (see [GH #25](https://github.com/vaam-store/image-resizer/issues/25)). |
-| `400 Bad Request` | The signed-URL path is malformed (bad processing option, missing/unrecognized extension, invalid base64/percent-encoding, ...), or the source URL doesn't decode as an image, or exceeds a configured size/resolution limit. `Cache-Control: no-store`. |
+| `301 Moved Permanently` | Resize succeeded. `Location` header points at the [download endpoint](#download-a-resized-image) for the result — never a redirect back to the caller-supplied source (see [GH #25](https://github.com/vaam-store/image-resizer/issues/25)). Carries `Vary: Accept` when the output format was resolved via `.auto` negotiation. |
+| `400 Bad Request` | The signed-URL path is malformed (bad processing option, option excluded by `ALLOWED_PROCESSING_OPTIONS`, unknown preset, missing/unrecognized extension, invalid base64/percent-encoding, ...), or the source URL doesn't decode as an image, or exceeds a configured size/resolution limit. `Cache-Control: no-store`. |
 | `403 Forbidden` | The signature is missing, invalid, or `unsigned` while `ALLOW_UNSIGNED_REQUESTS` isn't set. `Cache-Control: no-store`. |
-| `502 Bad Gateway` | The origin server for the source image failed (unreachable, non-2xx, or the connection dropped mid-transfer). `Cache-Control: no-store`. |
+| `502 Bad Gateway` | The origin server for the source image (or a watermark URL) failed (unreachable, non-2xx, or the connection dropped mid-transfer). `Cache-Control: no-store`. |
 | `503 Service Unavailable` | The service is shedding load (download/processing concurrency limits reached). `Cache-Control: no-store`. |
 
 ### Download a resized image
@@ -121,21 +436,21 @@ Unchanged from before #53, and deliberately **not** part of the signed-URL
 scheme above: it only ever serves bytes already produced and cached by a
 successful resize, addressed by a content hash that
 `key_validation::validate_cache_key` rejects anything malformed against
-(traversal, absolute paths, wrong shape) - there's no attacker-controlled
+(traversal, absolute paths, wrong shape) — there's no attacker-controlled
 fetch or CPU cost here to gate with a signature, unlike the resize route.
 
 Downloads a previously-resized image by its cache key (the value of the
-`Location` header from a successful resize above - not something you
-construct by hand). The key is exactly what
-`CacheService::generate_key` produces: an optional `STORAGE_SUB_PATH`
-prefix followed by a 64-character lowercase hex SHA-256 digest and one of
-`.jpg`/`.png`/`.webp`.
+`Location` header from a successful resize above — not something you
+construct by hand). The key is exactly what `CacheService::generate_key`
+produces: an optional `STORAGE_SUB_PATH` prefix followed by a
+64-character lowercase hex SHA-256 digest and one of
+`.jpg`/`.png`/`.webp`/`.avif`/`.gif`.
 
 #### Responses
 
 | Status | Meaning |
 |---|---|
-| `200 OK` | Returns the image bytes with `Content-Type` derived from the key's own extension (`image/jpeg`, `image/png`, or `image/webp`) and `Cache-Control: public, max-age=31536000, immutable`. |
+| `200 OK` | Returns the image bytes with `Content-Type` derived from the key's own extension (`image/jpeg`, `image/png`, `image/webp`, `image/avif`, or `image/gif` — `content_type_for_key`, `src/modules/api/download.rs:55-74`) and `Cache-Control: public, max-age=31536000, immutable`. |
 | `404 Not Found` | No image exists for the given key. `Cache-Control: no-store`. |
 | `502 Bad Gateway` | The storage backend failed to serve the image. `Cache-Control: no-store`. |
 
@@ -145,7 +460,7 @@ prefix followed by a 64-character lowercase hex SHA-256 digest and one of
 GET /health
 ```
 
-Returns `200 OK` with a plain-text body of `OK` - not JSON, and no
+Returns `200 OK` with a plain-text body of `OK` — not JSON, and no
 version field. `GET /` redirects here (`307 Temporary Redirect`).
 
 ### Metrics
@@ -158,7 +473,19 @@ Only mounted when the binary is built with `--features otel` (see
 [`src/modules/router/router.rs`](https://github.com/vaam-store/image-resizer/blob/main/src/modules/router/router.rs));
 absent otherwise. Returns metrics in Prometheus text format.
 
+**Requires a bearer token by default.** Send
+`Authorization: Bearer {METRICS_AUTH_TOKEN}`. A missing or wrong token
+returns `401 Unauthorized` with a `WWW-Authenticate: Bearer realm="metrics"`
+header (`src/modules/metrics_auth/middleware.rs:50-59`) — `401`, not
+`403`, since a corrected `Authorization` header on the *same* connection
+can succeed, unlike signed-URL verification. Like signing itself, this
+**fails closed at startup**: an `otel`-featured build with no
+`METRICS_AUTH_TOKEN` configured and no explicit
+`ALLOW_UNAUTHENTICATED_METRICS=true` refuses to start
+(`MetricsAuthConfig::from_env`, `src/modules/metrics_auth/config.rs:45-81`).
+See [Configuration](../getting-started/configuration.md#metrics-and-health-authentication).
+
 ## Error response body
 
-Error responses (`400`/`403`/`404`/`502`/`503` above) return a plain-text
-body (`content-type: text/plain`).
+Error responses (`400`/`403`/`401`/`404`/`502`/`503` above) return a
+plain-text body (`content-type: text/plain`).

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -1,29 +1,30 @@
 # Usage Examples
 
 Practical examples against the real, signed-URL API (see the
-[API reference](api-reference.md) for the full grammar). All examples below
-use the same placeholder key/salt as the API reference's worked example -
+[API reference](api-reference.md) for the full grammar, the pipeline
+order, and every option's divergence from imgproxy). Every URL below is a
+**genuine, working signature** — computed with the Python snippet under
+[Computing a signature](#computing-a-signature) against the same
+placeholder key/salt as the API reference's worked example:
 `SIGNING_KEY=6d792d7369676e696e672d6b6579`,
-`SIGNING_SALT=6d792d73616c74` (hex for `my-signing-key` / `my-salt`) -
-never use these for anything real.
+`SIGNING_SALT=6d792d73616c74` (hex for `my-signing-key` / `my-salt`) —
+never use these for anything real. Every example resizes
+`https://images.example.com/photo.jpg` unless noted otherwise.
 
 !!! note "The resize endpoint redirects, it doesn't stream bytes back"
     `GET /{signature}/{options}/{source}.{extension}` responds
     `301 Moved Permanently` with a `Location` header pointing at the
     resized image, rather than returning the image bytes directly.
     Browsers, `fetch()`, and `curl -L` all follow that redirect
-    transparently, so most of the examples below work unmodified - just be
+    transparently, so most of the examples below work unmodified — just be
     aware a plain `curl` (no `-L`) will save the (empty) redirect
     response, not an image.
 
-!!! note "Every example needs a real signature"
+!!! note "Every request needs a real signature"
     A request with a missing, wrong, or (unless `ALLOW_UNSIGNED_REQUESTS=true`
-    is set) `unsigned` signature gets `403 Forbidden`, never processed.
-    The signature is `base64url_nopad(HMAC-SHA256(key, salt || path))`
-    where `path` is everything in the URL *after* the signature segment
-    (leading `/` included). The Python snippet under
-    [Computing a signature](#computing-a-signature) below is the easiest
-    way to generate one for these examples.
+    is set) `unsigned` signature gets `403 Forbidden`, never processed. See
+    [Signing and fail-closed startup](api-reference.md#signature) in the
+    API reference for the exact HMAC scheme.
 
 ## Computing a signature
 
@@ -44,73 +45,207 @@ def encode_source(url: str) -> str:
 key_hex = "6d792d7369676e696e672d6b6579"
 salt_hex = "6d792d73616c74"
 
-source = encode_source("https://example.com/image.jpg")
-path = f"/rs:fill:800:600/{source}.jpg"
+source = encode_source("https://images.example.com/photo.jpg")
+path = f"/rs:fit:200:200/q:80/{source}.webp"
 signature = sign(key_hex, salt_hex, path)
 
 print(f"/{signature}{path}")
 ```
 
-## Basic resizing
+## Common cases
 
-### Resize to specific dimensions
-
-```
-GET /{signature}/rs:fill:800:600/{base64 source}.jpg
-```
-
-Resizes and crops to fill exactly 800x600.
-
-### Resize to a specific width only
+### Thumbnail
 
 ```
-GET /{signature}/rs::800:0/{base64 source}.jpg
+GET /USj4F2ERoKKugAeQ54JQct8oGudbkUzGYdIuJncZawk/rs:fit:200:200/q:80/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.webp
 ```
 
-`0` means "not set" for either dimension - only width is applied, height
-preserves aspect ratio.
+Resizes to fit inside a 200x200 box (aspect ratio preserved, so the
+output may be narrower or shorter than 200 on one axis), at quality 80,
+encoded as WebP.
 
-### Resize to a specific height only
-
-```
-GET /{signature}/rs::0:600/{base64 source}.jpg
-```
-
-## Format conversion
-
-### Convert to WebP
+### Fill-crop with gravity
 
 ```
-GET /{signature}/{base64 source}.webp
+GET /GsN7dLZQjyIq4gDj5iKQBZvL2HZu63AZd7o5vRU8pJM/rs:fill:400:300/gr:no/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Scales to *cover* 400x300, then crops the overflow anchored to the
+**north** edge (`gr:no`) instead of the default centre — useful when the
+interesting part of a photo (a face, a headline) sits near the top and a
+centred crop would cut it off.
+
+**Note the code is `gr:`, not `g:`.** This service's `g:` means grayscale,
+not gravity — see [the callout in the API reference](api-reference.md#the-most-important-divergence-from-imgproxy-g-is-grayscale-not-gravity)
+for why, and the [gravity migration example](#migrating-an-imgproxy-gravity-url)
+below for what happens if you use imgproxy's own `g:` by mistake.
+
+### Format conversion
+
+Convert to AVIF (smallest, most modern; encode-only in this service — see
+the [format table](api-reference.md#plainbase64-sourceextension)):
+
+```
+GET /X20ne2Igk1DfeVV6z5WxY5Be4X-Vbei4l55EfcDN1wE/q:70/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.avif
+```
+
+Convert to WebP with no other processing:
+
+```
+GET /V6QMdiu1wWZPyU7xF2lOlAVwzjUAZ_gK74g1N_InZ6Q/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.webp
 ```
 
 The trailing extension is always the output format, independent of the
 source's own extension or content type.
 
-### Convert to JPEG
+### Quality control
 
 ```
-GET /{signature}/{base64 source}.jpg
+GET /8rPY_ywRdyK5SJ0fkdkxHE4oJUYFZ7aHPEFdzWjebtE/rs:fit:1200:0/mb:150000/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
 ```
 
-## Quality, blur, and grayscale
+Resizes to fit within 1200px width (height `0` means "not set" — aspect
+ratio preserved), then encodes JPEG with quality iteratively lowered until
+the output is under 150,000 bytes (`mb:150000`). `mb:` only works for
+JPEG output here — see the [`mb:` row](api-reference.md#simple-options)
+in the API reference for why WebP/PNG/AVIF/GIF ignore it.
 
-### Encode quality
+### Watermarking
 
 ```
-GET /{signature}/q:80/{base64 source}.jpg
+GET /cGTrlLki-lIUwMLHKqrTPQzEbtGjpxY3NG6yZ4Yh1Zc/rs:fit:800:600/wm:0.6:soea:16:16:0.2/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
 ```
+
+Composites this deployment's default watermark image (`WATERMARK_URL` —
+see [Configuration](../getting-started/configuration.md)) at 60% opacity,
+anchored to the south-east corner with a 16px offset on each axis, scaled
+to 20% of the base image's size. To use a different, per-request
+watermark image instead of the deployment default, add `wmu:{base64url
+watermark URL}`. **Only image watermarks are supported** — there is no
+text-watermarking option in this grammar at all.
+
+### Presets
+
+Requires `PRESETS=thumbnail=rs:fill:300:300/q:80` (or similar) configured
+on the server — see [Presets and the allowlist](api-reference.md#presets-pr-and-the-processing-option-allowlist).
+
+```
+GET /_K8QuPpYQSz_HDfhaUaWE5Intcf5K0dBqP2MSgEWRK8/pr:thumbnail/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Expands to exactly `rs:fill:300:300/q:80` server-side. A request can still
+override part of what a preset sets, since segments apply left to right:
+
+```
+GET /i7IX-wbqFpioTVJYdJtAIEmu2lyH6ERZSOfZEFoIsec/pr:thumbnail/q:95/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Same 300x300 fill crop, but quality 95 instead of the preset's 80.
+
+### `.auto` content negotiation
+
+```
+GET /PxkE0dXMg8tHKsJKnbMkrUrA1tDnqVmjJvUGNyh8ji0/rs:fit:800:0/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.auto
+```
+
+`.auto` isn't a real output format — it's resolved against the request's
+`Accept` header before the image is ever processed
+(`crate::modules::negotiation::resolve`): AVIF if the client advertises
+it, else WebP, else JPEG, weighted by each entry's `q` parameter. The
+response carries `Vary: Accept` so caches don't serve a negotiated result
+to a client that asked for something different:
+
+```bash
+curl -L -o photo.avif \
+  -H 'Accept: image/avif,image/webp,image/*;q=0.8' \
+  "https://your-service.com/PxkE0dXMg8tHKsJKnbMkrUrA1tDnqVmjJvUGNyh8ji0/rs:fit:800:0/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.auto"
+```
+
+An explicit `.jpg`/`.png`/`.webp`/`.avif`/`.gif` extension is never
+affected by `Accept` — negotiation only ever happens for `.auto`.
+
+## Migrating an imgproxy gravity URL
+
+An imgproxy URL that anchors a fill crop with `g:no` (north gravity) does
+**not** silently produce a wrong-but-plausible result here — `g:` takes
+exactly one boolean argument in this service, and `no` fails to parse as
+one, so the request is rejected outright:
+
+```
+GET /{signature}/rs:fill:400:300/g:no/{base64 source}.jpg
+→ 400 Bad Request: invalid value for processing option "g:no"
+```
+
+The fix is to rewrite `g:` to `gr:` for gravity, keeping `g:` reserved for
+grayscale:
+
+```
+GET /BBpe0KuAM-evlv6Imxy44EEt5Xk5gVRyIjaTL5nKKf0/gr:no/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+## More processing options
 
 ### Grayscale
 
 ```
-GET /{signature}/rs:fill:800:600/g:true/{base64 source}.jpg
+GET /7Ydb5QQ5ZSOybTjD0wfHE6yBT-kpDSgd4xXZ9EwDhfc/g:true/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
 ```
 
-### Gaussian blur
+### Explicit crop
 
 ```
-GET /{signature}/rs:fill:800:600/bl:8/{base64 source}.jpg
+GET /LdpbqOKHQgoBoq6W4hx_NEPgHNWyyHJFKCKoNbn5s6s/c:0.5:0.5:noea/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Crops to 50% of the source's width and height (`0.5` is a relative
+fraction, since it's under `1.0`), anchored to the north-east corner.
+
+### Trim and padding
+
+```
+GET /iBTsc8J02JiEo6WN4oFMrFk8wGsFWvsJk7DZDtlmcH8/t:10/pd:20/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.png
+```
+
+Trims uniform-colour borders (threshold `10`, auto-detected from the
+top-left pixel), then pads the trimmed image by 20px on every side
+(`pd:20` — CSS-shorthand style, so a single value applies to all four
+sides).
+
+### Rotate and flip
+
+```
+GET /NeWEj5rX0EiNuc4olyJKkhqgxIfmSlpze7z0TPBLeJA/rot:90/fl:1:0/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Rotates 90° clockwise, then flips horizontally only. Both run *after*
+resize — see [the pipeline order diagram](api-reference.md#processing-pipeline-order)
+in the API reference.
+
+### Responsive images with `dpr`
+
+```
+GET /8xN0tTepw8WnOinCA-oAbHMDBfIw5plK1bW7orSS87E/rs:fit:300:0/dpr:2/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Requests a 300 CSS-px-wide slot on a 2x-density screen — the actual
+resized output is 600px wide. `dpr:` (like `z:`) only scales an axis that
+already has an explicit width or height set.
+
+### JPEG tuning
+
+```
+GET /Ak3BWWUBgmlzDcM-GVlhHk4aiUOMNx6jBPKXIjsUHPM/jpgo:1:1/q:85/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.jpg
+```
+
+Progressive JPEG (`jpgo:1:...`) with full-resolution 4:4:4 chroma
+(`jpgo:...:1`, instead of this service's default 4:2:2), quality 85. Only
+the first two of imgproxy's six `jpgo:` slots exist here — see
+[JPEG tuning](api-reference.md#jpeg-tuning-jpgo) in the API reference.
+
+### Lossless WebP
+
+```
+GET /rsHnTgOJn7x03v3BhpexkmKoykNr8l-ivAMKc1GYUOk/webpo:lossless/aHR0cHM6Ly9pbWFnZXMuZXhhbXBsZS5jb20vcGhvdG8uanBn.webp
 ```
 
 ### Combining options
@@ -119,10 +254,13 @@ Processing options can be freely combined as additional `/`-delimited
 segments, in any order:
 
 ```
-GET /{signature}/rs:fill:800:600/q:80/bl:5/g:true/el:1/{base64 source}.webp
+GET /vtDmKFzheWdTv2Q8Kv2BVx0o77KVyvif0Z2nfxBlSEQ/rs:fill:800:600/q:80/bl:5/g:true/el:1/aHR0cHM6Ly9leGFtcGxlLmNvbS9pbWFnZS5qcGc.webp
 ```
 
-## Using a plain (non-base64) source URL
+Fill-crops to 800x600, quality 80, blur sigma 5, grayscale, enlarge
+permitted, output WebP.
+
+### Using a plain (non-base64) source URL
 
 The `plain/` form skips base64 encoding, at the cost of needing the URL's
 own reserved characters percent-encoded:


### PR DESCRIPTION
## Summary

Every document in the repository re-verified against the code. Four parallel passes over disjoint file sets — 15 files, +2314/−736.

## Intent

Documentation had drifted far enough to be actively misleading. Three files described components that no longer exist, seven predated the entire parity epic, and the user-facing API reference documented **6 of 28** processing options.

## Scope

| Area | State before | Now |
|---|---|---|
| `docs/user-guide/api-reference.md` | 6 options; cited deleted `openapi.yaml` | **28 options**, syntax/defaults/behaviour, `file:line` citations, pipeline diagram |
| `docs/user-guide/examples.md` | stale | real signed URLs, HMACs verified |
| `README.md` | cited `openapi.yaml`, `make init` | rewritten; request-flow diagram; honest performance section |
| `PERFORMANCE_OPTIMIZATIONS.md` | described a **rayon** pool | rewritten; defers all numbers to `BASELINE.md` |
| `docs/configuration/performance.md` | stale benchmark env vars | corrected; documents four previously-undocumented vars |
| `docs/architecture/*` | generated OpenAPI server, rayon, framework hedged as "Axum/Actix/Rocket" | rewritten; sequence + state diagrams, every transition cited |
| `docs/index.md`, `installation.md` | predated the epic | feature flags, both fail-closed startup checks with exact remedies |
| `docs/deployment/*` | stale | four image flavours, the bookworm/glibc pin rationale, verified workarounds |
| `docs/development/*` | missing `--no-default-features`, no otel leg | matches the CI matrix; documents `check_env_docs.py` and `bench-imgproxy/` |
| `docs/about/changelog.md` | 20 lines, predated everything | reconstructed from 90 merge commits, grouped by theme, breaking changes called out |
| `docs/about/license.md` | bare LICENSE copy | includes the `NOTICE` IJG/libwebp attributions |

## A correction to `adr/0002`, which I wrote and got wrong

It claimed an imgproxy gravity URL is **"silently misread"** here. It is not. `g:` routes its argument through `parse_bool` (`src/modules/url/options.rs`), which accepts only `true`/`1`/`false`/`0` — so every imgproxy gravity token (`ce`, `no`, `so`, `we`, `noea`, `sowe`, `sm`, `fp`) fails to parse and the request is rejected with **400 Bad Request**. `g:ce:10:20` fails the arity check first, same outcome.

The real behaviour is better than what was documented: a migrating user gets a loud error at the boundary rather than a wrong image. The original claim was written from the shape of the grammar without checking the parser. It is corrected in place with the reasoning kept visible, because "silently misread" is exactly the sort of claim that would justify reopening that decision on false grounds.

## Verification

- **HMAC signatures in `examples.md` independently recomputed** from the documented key/salt — they match, so the example URLs genuinely work rather than being placeholders.
- **All 27 `file:line` citations in the architecture docs resolve** to real, semantically appropriate lines (the agent's first pass had several approximated from memory; those were corrected before commit and re-checked here).
- **The 301 claim verified**, including the subtlety that axum's `Redirect::permanent` would issue 308 — which is why the code builds the response by hand.
- **No overlap between the four branches** — confirmed before merging, so the integration is a clean union rather than a resolved conflict.
- `grep` for `openapi`, `make init`, `rayon`, `gen-server` across all docs returns only clearly-marked historical mentions.

## Four defects found, filed rather than fixed here

Writing down what the code actually does is what surfaced them. A documentation branch should not quietly change runtime behaviour, so all four are separate issues:

- **#83** — `enable_http2` is `false` in the no-profile fallback while `Default::default()` and two of three profiles set `true`. The ordinary deployment (no `PERFORMANCE_PROFILE`, no `ENABLE_HTTP2`) therefore runs with HTTP/2 off. Existing tests cover only the two explicit cases, never the `None` path that diverges.
- **#84** — `compose.yaml` and **both** Helm charts omit `SIGNING_KEY`/`SIGNING_SALT`/`ALLOW_UNSIGNED_REQUESTS`, so every shipped deployment path crash-loops against the fail-closed check from #27. CI proves the *image* boots but never brings up the manifests users actually run.
- **#85** — `helm/serverless` renders `ghcr.io/ghcr.io/...` (registry and repository both carry the prefix), ships `${LOG_LEVEL:-info}` as a literal string Helm never expands, and defaults to an unpublished `latest` tag.

The docs describe current reality including these defects, with verified workarounds, rather than describing an aspiration.

## Risk Assessment

- Documentation only; no source, workflow or dependency changes.
- The performance sections state the cold gap (3.26× slower than imgproxy) plainly. Documentation claiming parity this project does not have would be worse than none. The warm figure (0.39 ms) never appears without its caveat that imgproxy has no result cache, so warm measures an architectural difference rather than processing speed.
- `PERFORMANCE_OPTIMIZATIONS.md` was kept rather than deleted — it holds unique mechanism-level reasoning (why `spawn_blocking` and not rayon, buffer-copy details, build-profile rationale) that exists nowhere else — but it now defers every number to `BASELINE.md` so the two cannot drift apart again.

## Reviewer Focus

1. The `g:`/gravity correction in `adr/0002` — whether 400-on-parse-failure is accurately described, since this reverses a claim that has been quoted elsewhere.
2. `api-reference.md`'s divergence list. These are the claims a drop-in-compatibility promise lives or dies on: `mb:` is JPEG-only, `z:`/`dpr:` need explicit dimensions, directional gravity takes no offset nudge, `ex:` rejects imgproxy's gravity argument, `jpgo:` implements 2 of 6 slots and `webpo:` 1 of 3.
3. Whether the deployment docs should describe the #84/#85 workarounds at all, or wait for the fixes.

## AI Usage Declaration

AI (Claude Opus 5 orchestrating four Sonnet sub-agents over disjoint file sets) performed this pass. The orchestrator verified independently rather than accepting reports: recomputing an example HMAC in Python, resolving every architecture citation to its line, confirming the `parse_bool` behaviour that overturned the ADR claim, checking branch-file overlap before merging, and reproducing all four filed defects directly against the manifests and source.

- [x] A human is accountable for this change.
- [x] Claims are verified against code, not against prior documentation.
- [x] An error of mine in an existing ADR is corrected in place with the reasoning visible, and the defects found are filed rather than silently patched.
